### PR TITLE
Add word boundary to all labeled answers

### DIFF
--- a/curated-full.tsv
+++ b/curated-full.tsv
@@ -1,867 +1,867 @@
-1756	factoid	When is Fashion week in NYC?	Sept?(ember)?|Feb(ruary)?
-1434	factoid	What site did Lindbergh begin his flight from in 1927?	Long Island|New\s?York|Roosevelt Field
-1790	factoid	What country is the holy city of Mecca located in?	Saudi Arabia
-1992	factoid	How hot is the sun?	(5,?778|6,?[05]00)\s*K|(5,?505|6,?[50]00).*C|(9,?941|10,?000).*F|5778\.0
-2128	factoid	What flavor filling did the original Twinkies have?	banana
-1840	factoid	What is the state song of Kansas?	Home on the Range
-1689	factoid	What war is connected with the book "Charge of the Light Brigade"?	Crimean
-10040	factoid	Where was the first atomic bomb detonated?	White Sands|New Mexico
-1647	factoid	What continent is Scotland in?	Europe
-1808	factoid	What island did the U.S. gain after the Spanish American war?	Cuba|Guam|Puerto Rico
-1439	factoid	How deep is Crater Lake?	1\s?,\s?932 feet|1,?949\s*f(ee|oo)?t|594\s*m|593 m|593\.0|594\.0552
-1663	factoid	What are the people who make fireworks called?	Pyrotechnists
-1535	factoid	Who painted "Sunflowers"?	van Gogh
-10048	factoid	Who played Frodo in Lord of The Rings?	Wood
-10017	factoid	What is the capital of Laos?	Vientiane
-2364	factoid	How hot does it get in Death Valley?	\b134\b|56\.7|\b116\b|\b47\b|56\.6\°C
-1550	factoid	What is the southwestern-most tip of England?	Cornwall
-1873	factoid	What is the motto for California?	.*Eureka.*
-2067	factoid	How many Great Lakes are there?	five
-10028	factoid	What is the name of the second Beatles album?	Second Album|Introducing\.\.\. The Beatles
-10002	factoid	How many bombs were detonated in 2005 in London?	four|\b4\b
-2248	factoid	How many planets are in our solar system?	nine|\b9\b|eight|\b8\b
-2275	factoid	How big is the planet Venus?	3,?7[5-7][0-9]\s*miles|6,?05[0-9]\s*(km|kilometers)
-1617	factoid	When did the Klondike gold rush occur?	189[6789]
-2094	factoid	When was JFK born?	1917
-2344	factoid	What city hosted the 1936 Summer Olympics?	Berlin
-1850	factoid	What is Marilyn Monroe's real name?	Norma Jeane? (Baker|Mortenson)|Norma Jean
-2149	factoid	How many Olympic gold medals did Carl Lewis win?	ten|\b10\b|nine
-1402	factoid	What year did Wilt Chamberlain score 100 points?	1962
-1897	factoid	What is the name of the airport in Dallas Ft. Worth?	Dallas(\s\/\s|\-)Fort Worth International Airport|Dallas\/Fort Worth International Airport
-1822	factoid	Who was the captain of the Titanic?	Smith
-1588	factoid	When was Apollo 11 launched?	1969
-10019	factoid	What is the color of pea?	green|yellow
-1852	factoid	When did Henry VIII rule England?	16th\s*century|1509.*1547|1509|1551|28 June 1491 \– 28 January 1547
+1756	factoid	When is Fashion week in NYC?	\bSept?(ember)?\b|\bFeb(ruary)?\b
+1434	factoid	What site did Lindbergh begin his flight from in 1927?	\bLong Island\b|\bNew\s?York\b|\bRoosevelt Field\b
+1790	factoid	What country is the holy city of Mecca located in?	\bSaudi Arabia\b
+1992	factoid	How hot is the sun?	\b(5,?778|6,?[05]00)\s*K\b|\b(5,?505|6,?[50]00).*C\b|\b(9,?941|10,?000).*F\b|\b5778\.0\b
+2128	factoid	What flavor filling did the original Twinkies have?	\bbanana\b
+1840	factoid	What is the state song of Kansas?	\bHome on the Range\b
+1689	factoid	What war is connected with the book "Charge of the Light Brigade"?	\bCrimean\b
+10040	factoid	Where was the first atomic bomb detonated?	\bWhite Sands\b|\bNew Mexico\b
+1647	factoid	What continent is Scotland in?	\bEurope\b
+1808	factoid	What island did the U.S. gain after the Spanish American war?	\bCuba\b|\bGuam\b|\bPuerto Rico\b
+1439	factoid	How deep is Crater Lake?	\b1\s?,\s?932 feet\b|\b1,?949\s*f(ee|oo)?t\b|\b594\s*m\b|\b593 m\b|\b593\.0\b|\b594\.0552\b
+1663	factoid	What are the people who make fireworks called?	\bPyrotechnists\b
+1535	factoid	Who painted "Sunflowers"?	\bvan Gogh\b
+10048	factoid	Who played Frodo in Lord of The Rings?	\bWood\b
+10017	factoid	What is the capital of Laos?	\bVientiane\b
+2364	factoid	How hot does it get in Death Valley?	\b134\b|\b56\.7\b|\b116\b|\b47\b|\b56\.6\°C\b
+1550	factoid	What is the southwestern-most tip of England?	\bCornwall\b
+1873	factoid	What is the motto for California?	\b.*Eureka.*\b
+2067	factoid	How many Great Lakes are there?	\bfive\b
+10028	factoid	What is the name of the second Beatles album?	\bSecond Album\b|\bIntroducing\.\.\. The Beatles\b
+10002	factoid	How many bombs were detonated in 2005 in London?	\bfour\b|\b4\b
+2248	factoid	How many planets are in our solar system?	\bnine\b|\b9\b|\beight\b|\b8\b
+2275	factoid	How big is the planet Venus?	\b3,?7[5-7][0-9]\s*miles\b|\b6,?05[0-9]\s*(km|kilometers)\b
+1617	factoid	When did the Klondike gold rush occur?	\b189[6789]\b
+2094	factoid	When was JFK born?	\b1917\b
+2344	factoid	What city hosted the 1936 Summer Olympics?	\bBerlin\b
+1850	factoid	What is Marilyn Monroe's real name?	\bNorma Jeane? (Baker|Mortenson)\b|\bNorma Jean\b
+2149	factoid	How many Olympic gold medals did Carl Lewis win?	\bten\b|\b10\b|\bnine\b
+1402	factoid	What year did Wilt Chamberlain score 100 points?	\b1962\b
+1897	factoid	What is the name of the airport in Dallas Ft. Worth?	\bDallas(\s\/\s|\-)Fort Worth International Airport\b|\bDallas\/Fort Worth International Airport\b
+1822	factoid	Who was the captain of the Titanic?	\bSmith\b
+1588	factoid	When was Apollo 11 launched?	\b1969\b
+10019	factoid	What is the color of pea?	\bgreen\b|\byellow\b
+1852	factoid	When did Henry VIII rule England?	\b16th\s*century\b|\b1509.*1547\b|\b1509\b|\b1551\b|\b28 June 1491 \– 28 January 1547\b
 10073	factoid	what is the atomic number of molybdenum?	\b42\b
-2186	factoid	What are the measurements for a king-size bed?	76\s*(inch|").*80\s*(inch|")
-1456	factoid	What is the Keystone State?	Pennsylvania
-10081	factoid	what is the name of the Doctor's wife in the long eunning BBC TV series Doctor Who.	River Song
-1394	factoid	In what country did the game of croquet originate?	French|France|Great Britain and Switzerland \–
-1695	factoid	What breed was Roy Rogers' horse Trigger?	palomino
-1459	factoid	What is one national park in Indiana?	Indiana Dunes National Lakeshore
-2215	factoid	What are sounds too low for humans to hear called?	infrasonic|infrasound
-2210	factoid	How many grams in an ounce?	28|30
-1572	factoid	For whom was the state of Pennsylvania named?	William Penn
-10036	factoid	When was the first of the International Mathematical Olympiads held?	1959
-1762	factoid	What is the name of Scarlett O'Hara's house?	Tara
-1627	factoid	What is written on the U.S. tomb of the unknown soldier?	Here Rests In Honored Glory An American Soldier Known But To God
-2365	factoid	What body of water does the Colorado River empty into?	Gulf of California
-10091	factoid	when was Voyager 1 launched?	1977
-1722	factoid	What year did poet Emily Dickinson die?	1886
-2232	factoid	What daughter of Czar Nicholas II is said to have escaped death in the Russian revolution?	Anastasia
-2307	factoid	How many terms was Dwight D. Eisenhower president?	\b2\b|two
-1678	factoid	Who was the U.S. president in 1929?	Hoover
-2011	factoid	When was Leonardo da Vinci born?	1452
-2317	factoid	What team drafted Brett Favre?	Atlanta|Falcons
-2170	factoid	How often does the men's soccer World Cup take place?	four year|4 year
-2375	factoid	What date did Thomas Jefferson die?	4 July? 1826|July? 4.*?1826
-2188	factoid	Who sang "Tennessee Waltz"?	Patti Page
-2393	factoid	What color hair did Thomas Jefferson have before gray?	\bred
-2361	factoid	What stadium was the first televised MLB game played in?	Ebbets Field
-1530	factoid	What is the capital city of New Zealand?	Wellington
-1582	factoid	How high is a hand?	4\s*in(ches)?
-2378	factoid	How did Bob Marley die?	cancer|melanoma
-2080	factoid	What peace treaty ended WWI?	Versailles|Lausanne
-1773	factoid	What was Aaron Copland's most famous piece of music?	Appalachian Spring|Billy the Kid|Rodeo|Fanfare for the Common Man|Third Symphony
-10022	factoid	What is the density of gold?	\b19\.3.*cm|\b19,?3.*kg|11\,340\ kg\/m3|19\.32 grams per cubic centimeter at 20 \°C
-1638	factoid	What city in Australia has rain forests?	Cairns|Daintree|Port Douglas
-2124	factoid	What organization did Paul Konerko first play major league baseball with?	Dodgers
-1752	factoid	When was the Oklahoma City bombing?	1995
-2062	factoid	How many legs does a beetle have?	six|\b6\b
-1667	factoid	What is the abbreviation for the London stock exchange?	L.?S.?E.?
-1748	factoid	When were the Los Angeles riots?	(19|4/30/)92
-1490	factoid	What is the Boston Strangler's name?	Albert DeSalvo
-1826	factoid	Which film received the first best picture Academy Award?	.*Wings.*
-1503	factoid	What is the world's second largest island?	New Guinea
-1549	factoid	What year was the IBM PC invented?	1981
+2186	factoid	What are the measurements for a king-size bed?	\b76\s*(inch|").*80\s*(inch|")\b
+1456	factoid	What is the Keystone State?	\bPennsylvania\b
+10081	factoid	what is the name of the Doctor's wife in the long eunning BBC TV series Doctor Who.	\bRiver Song\b
+1394	factoid	In what country did the game of croquet originate?	\bFrench\b|\bFrance\b|\bGreat Britain and Switzerland \–\b
+1695	factoid	What breed was Roy Rogers' horse Trigger?	\bpalomino\b
+1459	factoid	What is one national park in Indiana?	\bIndiana Dunes National Lakeshore\b
+2215	factoid	What are sounds too low for humans to hear called?	\binfrasonic\b|\binfrasound\b
+2210	factoid	How many grams in an ounce?	\b28\b|\b30\b
+1572	factoid	For whom was the state of Pennsylvania named?	\bWilliam Penn\b
+10036	factoid	When was the first of the International Mathematical Olympiads held?	\b1959\b
+1762	factoid	What is the name of Scarlett O'Hara's house?	\bTara\b
+1627	factoid	What is written on the U.S. tomb of the unknown soldier?	\bHere Rests In Honored Glory An American Soldier Known But To God\b
+2365	factoid	What body of water does the Colorado River empty into?	\bGulf of California\b
+10091	factoid	when was Voyager 1 launched?	\b1977\b
+1722	factoid	What year did poet Emily Dickinson die?	\b1886\b
+2232	factoid	What daughter of Czar Nicholas II is said to have escaped death in the Russian revolution?	\bAnastasia\b
+2307	factoid	How many terms was Dwight D. Eisenhower president?	\b2\b|\btwo\b
+1678	factoid	Who was the U.S. president in 1929?	\bHoover\b
+2011	factoid	When was Leonardo da Vinci born?	\b1452\b
+2317	factoid	What team drafted Brett Favre?	\bAtlanta\b|\bFalcons\b
+2170	factoid	How often does the men's soccer World Cup take place?	\bfour year\b|\b4 year\b
+2375	factoid	What date did Thomas Jefferson die?	\b4 July? 1826\b|\bJuly? 4.*?1826\b
+2188	factoid	Who sang "Tennessee Waltz"?	\bPatti Page\b
+2393	factoid	What color hair did Thomas Jefferson have before gray?	\bred\b
+2361	factoid	What stadium was the first televised MLB game played in?	\bEbbets Field\b
+1530	factoid	What is the capital city of New Zealand?	\bWellington\b
+1582	factoid	How high is a hand?	\b4\s*in(ches)?\b
+2378	factoid	How did Bob Marley die?	\bcancer\b|\bmelanoma\b
+2080	factoid	What peace treaty ended WWI?	\bVersailles\b|\bLausanne\b
+1773	factoid	What was Aaron Copland's most famous piece of music?	\bAppalachian Spring\b|\bBilly the Kid\b|\bRodeo\b|\bFanfare for the Common Man\b|\bThird Symphony\b
+10022	factoid	What is the density of gold?	\b19\.3.*cm\b|\b19,?3.*kg\b|\b11\,340\ kg\/m3\b|\b19\.32 grams per cubic centimeter at 20 \°C\b
+1638	factoid	What city in Australia has rain forests?	\bCairns\b|\bDaintree\b|\bPort Douglas\b
+2124	factoid	What organization did Paul Konerko first play major league baseball with?	\bDodgers\b
+1752	factoid	When was the Oklahoma City bombing?	\b1995\b
+2062	factoid	How many legs does a beetle have?	\bsix\b|\b6\b
+1667	factoid	What is the abbreviation for the London stock exchange?	\bL.?S.?E.?\b
+1748	factoid	When were the Los Angeles riots?	\b(19|4/30/)92\b
+1490	factoid	What is the Boston Strangler's name?	\bAlbert DeSalvo\b
+1826	factoid	Which film received the first best picture Academy Award?	\b.*Wings.*\b
+1503	factoid	What is the world's second largest island?	\bNew Guinea\b
+1549	factoid	What year was the IBM PC invented?	\b1981\b
 2333	factoid	How old do you have to be to join the U.S. Navy?	\b17\b
-1698	factoid	When was Julius Caesar born?	100\s*B.?C.?|B.?C.?\s*100
-1728	factoid	When did Yankee Stadium first open?	1923
-1910	factoid	What are pennies made of?	zinc|copper|brass|bronze|steel
-10064	factoid	how much is 1+1?	\b2\b|two
-10015	factoid	What is capital city of Russia?	Moscow
-1471	factoid	How fast can a cheetah run?	120\s*km/?h|75\s*mph
-2335	factoid	How did Harry Chapin die?	car accident|car crash|traffic
-2302	factoid	How much did the first Barbie cost?	\b3\b|three
-2076	factoid	What company owns the soft drink brand "Gatorade"?	Quaker Oats|PepsiCo
-1424	factoid	Who won the Oscar for best actor in 1970?	George C. Scott|Scott
-1772	factoid	Who invented the cotton gin?	Whitney
-10035	factoid	When was Maria Theresa born?	1717
-2360	factoid	What is the gift for the 20th anniversary?	china|platinum
-1651	factoid	What is another name for the North Star?	Polaris
-10056	factoid	how did stalin die?	stroke|cerebral hemorrhage
-1981	factoid	How long is the Great Barrier Reef?	1,?(200|250|400)\s*miles?|(2,?000|2,?300)\s*(km|kilometers)
-1463	factoid	What is the North Korean national anthem?	Patriotic Song|Aegukka|Let Morning Shine|the national anthem
-1521	factoid	What year did Ellis Island open its doors to immigrants?	1892
-1797	factoid	How did Adolf Hitler die?	committed suicide|Suicide|April 1945|Ballistic trauma
-1720	factoid	When a game of baseball is forfeited, what is the score?	9\s*[:-]\s*0
-2288	factoid	What animal is veal from?	cal(f|ves)|cows|Cattle
-2336	factoid	How many layers of skin do we have?	\b3\b|seven|three|\b7\b
-1529	factoid	What is the oldest college bowl game?	Rose Bowl Game|Rose Bowl
-1788	factoid	Who makes viagra?	Pfizer
-2089	factoid	On what Caribbean Island was Ponce de Leon governor?	Puerto Rico('s)?
-1699	factoid	What city is Purdue University in?	West Lafayette|Lafayette
-1928	factoid	how did Patsy Cline die	plane crash|crash.*plane|Aviation accident or incident
-1723	factoid	What is Madonna's last name?	Ciccone
-10058	factoid	how long does light travel from sun to earth?	(49[0-9]|50[0-9])\s*s|8.*min
-1744	factoid	What car company invented the Edsel?	Ford
-10014	factoid	What is Albert Einstein's surname?	Einstein
-1686	factoid	Who defeated the Spanish armada?	Drake|Engl(and|ish)
-2020	factoid	In which city would you find the Louvre?	Paris
-10055	factoid	how did hitler die?	suicide|ballistic|shoo?t
-10049	factoid	Who received the Nobel Prize in Physiology or Medicine in 1962?	((Crick|Watson|Wilkins).*){3}|Francis Crick|Maurice Wilkins
-1566	factoid	What famous Spanish poet died in Spain's Civil War?	Lorca
-1726	factoid	What is the name of the canopy at a Jewish wedding?	c?hup?pah?|chipe|chuppot
-2047	factoid	How close is Mercury to the sun?	(3[56].*million|35,?980,?000)\s*miles|(57,?910,?000|5[78].*million)\s*(km|kilometers)
-1946	factoid	What day and month did Nixon resign?	9[^0-9]*Aug(ust)?|Aug(ust)?[^0-9]*9
-1730	factoid	What is Mark Twain's real name?	Samuel.*Clemens
-10070	factoid	what is capital city of czech republic?	Prague|Praha
-2001	factoid	What rock band sang "A Whole Lotta Love"?	Led Zeppelin
-1943	factoid	What is the name of Ling Ling's mate?	Ahua|Hsing-Hsing|Tong Tong
-2073	factoid	How fast does light travel through space?	186,?(282|000) miles per second|(299,?792|300,?000) kilometers per second|299,?792,?458 met(re|er)s per second|671 million miles per hour
-2084	factoid	How many home runs did Babe Ruth hit?	714|104
-2286	factoid	What is an Indian flute made of?	cane|wood|Bamboo
-1527	factoid	When did the 6-day war begin?	June 5\s?, 1967|1967
-1807	factoid	What is the range for the number of passengers a Boeing 747-400 airplane can carry?	416|524|660|Ansett Australia\'s retrofitted two Boeing 747\-400 series aircraft
-2353	factoid	What did Osama bin Laden's father do for a living?	construction|business
-1739	factoid	What is the full name of conductor Seiji?	Seiji Ozawa
-2362	factoid	How high is Pikes peak?	14,?11[0-9]\s*('|f(ee|oo)?t)|4,?30[0-9]\s*m|more than 14000 ft
-1974	factoid	What is Richie's surname on "Happy Days"?	Cunningham
-1620	factoid	What year was the first Macy's Thanksgiving Day Parade held?	1924
-1882	factoid	What nationality is Sean Connery?	Scot(tish)?
-2159	factoid	What country singer's first album was titled "Storms of Life"?	Randy Travis
+1698	factoid	When was Julius Caesar born?	\b100\s*B.?C.?\b|\bB.?C.?\s*100\b
+1728	factoid	When did Yankee Stadium first open?	\b1923\b
+1910	factoid	What are pennies made of?	\bzinc\b|\bcopper\b|\bbrass\b|\bbronze\b|\bsteel\b
+10064	factoid	how much is 1+1?	\b2\b|\btwo\b
+10015	factoid	What is capital city of Russia?	\bMoscow\b
+1471	factoid	How fast can a cheetah run?	\b120\s*km/?h\b|\b75\s*mph\b
+2335	factoid	How did Harry Chapin die?	\bcar accident\b|\bcar crash\b|\btraffic\b
+2302	factoid	How much did the first Barbie cost?	\b3\b|\bthree\b
+2076	factoid	What company owns the soft drink brand "Gatorade"?	\bQuaker Oats\b|\bPepsiCo\b
+1424	factoid	Who won the Oscar for best actor in 1970?	\bGeorge C. Scott\b|\bScott\b
+1772	factoid	Who invented the cotton gin?	\bWhitney\b
+10035	factoid	When was Maria Theresa born?	\b1717\b
+2360	factoid	What is the gift for the 20th anniversary?	\bchina\b|\bplatinum\b
+1651	factoid	What is another name for the North Star?	\bPolaris\b
+10056	factoid	how did stalin die?	\bstroke\b|\bcerebral hemorrhage\b
+1981	factoid	How long is the Great Barrier Reef?	\b1,?(200|250|400)\s*miles?\b|\b(2,?000|2,?300)\s*(km|kilometers)\b
+1463	factoid	What is the North Korean national anthem?	\bPatriotic Song\b|\bAegukka\b|\bLet Morning Shine\b|\bthe national anthem\b
+1521	factoid	What year did Ellis Island open its doors to immigrants?	\b1892\b
+1797	factoid	How did Adolf Hitler die?	\bcommitted suicide\b|\bSuicide\b|\bApril 1945\b|\bBallistic trauma\b
+1720	factoid	When a game of baseball is forfeited, what is the score?	\b9\s*[:-]\s*0\b
+2288	factoid	What animal is veal from?	\bcal(f|ves)\b|\bcows\b|\bCattle\b
+2336	factoid	How many layers of skin do we have?	\b3\b|\bseven\b|\bthree\b|\b7\b
+1529	factoid	What is the oldest college bowl game?	\bRose Bowl Game\b|\bRose Bowl\b
+1788	factoid	Who makes viagra?	\bPfizer\b
+2089	factoid	On what Caribbean Island was Ponce de Leon governor?	\bPuerto Rico('s)?\b
+1699	factoid	What city is Purdue University in?	\bWest Lafayette\b|\bLafayette\b
+1928	factoid	how did Patsy Cline die	\bplane crash\b|\bcrash.*plane\b|\bAviation accident or incident\b
+1723	factoid	What is Madonna's last name?	\bCiccone\b
+10058	factoid	how long does light travel from sun to earth?	\b(49[0-9]|50[0-9])\s*s\b|\b8.*min\b
+1744	factoid	What car company invented the Edsel?	\bFord\b
+10014	factoid	What is Albert Einstein's surname?	\bEinstein\b
+1686	factoid	Who defeated the Spanish armada?	\bDrake\b|\bEngl(and|ish)\b
+2020	factoid	In which city would you find the Louvre?	\bParis\b
+10055	factoid	how did hitler die?	\bsuicide\b|\bballistic\b|\bshoo?t\b
+10049	factoid	Who received the Nobel Prize in Physiology or Medicine in 1962?	\b((Crick|Watson|Wilkins).*){3}\b|\bFrancis Crick\b|\bMaurice Wilkins\b
+1566	factoid	What famous Spanish poet died in Spain's Civil War?	\bLorca\b
+1726	factoid	What is the name of the canopy at a Jewish wedding?	\bc?hup?pah?\b|\bchipe\b|\bchuppot\b
+2047	factoid	How close is Mercury to the sun?	\b(3[56].*million|35,?980,?000)\s*miles\b|\b(57,?910,?000|5[78].*million)\s*(km|kilometers)\b
+1946	factoid	What day and month did Nixon resign?	\b9[^0-9]*Aug(ust)?\b|\bAug(ust)?[^0-9]*9\b
+1730	factoid	What is Mark Twain's real name?	\bSamuel.*Clemens\b
+10070	factoid	what is capital city of czech republic?	\bPrague\b|\bPraha\b
+2001	factoid	What rock band sang "A Whole Lotta Love"?	\bLed Zeppelin\b
+1943	factoid	What is the name of Ling Ling's mate?	\bAhua\b|\bHsing-Hsing\b|\bTong Tong\b
+2073	factoid	How fast does light travel through space?	\b186,?(282|000) miles per second\b|\b(299,?792|300,?000) kilometers per second\b|\b299,?792,?458 met(re|er)s per second\b|\b671 million miles per hour\b
+2084	factoid	How many home runs did Babe Ruth hit?	\b714\b|\b104\b
+2286	factoid	What is an Indian flute made of?	\bcane\b|\bwood\b|\bBamboo\b
+1527	factoid	When did the 6-day war begin?	\bJune 5\s?, 1967\b|\b1967\b
+1807	factoid	What is the range for the number of passengers a Boeing 747-400 airplane can carry?	\b416\b|\b524\b|\b660\b|\bAnsett Australia\'s retrofitted two Boeing 747\-400 series aircraft\b
+2353	factoid	What did Osama bin Laden's father do for a living?	\bconstruction\b|\bbusiness\b
+1739	factoid	What is the full name of conductor Seiji?	\bSeiji Ozawa\b
+2362	factoid	How high is Pikes peak?	\b14,?11[0-9]\s*('|f(ee|oo)?t)\b|\b4,?30[0-9]\s*m\b|\bmore than 14000 ft\b
+1974	factoid	What is Richie's surname on "Happy Days"?	\bCunningham\b
+1620	factoid	What year was the first Macy's Thanksgiving Day Parade held?	\b1924\b
+1882	factoid	What nationality is Sean Connery?	\bScot(tish)?\b
+2159	factoid	What country singer's first album was titled "Storms of Life"?	\bRandy Travis\b
 10074	factoid	what is the critical angle of rainbow?	\b48\b
-1446	factoid	How did Mahatma Gandhi die?	\bshot|shooting|Assassination
-2328	factoid	What state was Amelia Earhart born in?	Kan(sas|.)
-1934	factoid	What is the play "West Side Story" based on?	Romeo and Juliet|a 1961 American romantic musical drama film
-1407	factoid	When did the shootings at Columbine happen?	April 20\s?, 1999|1999|April 20
-2339	factoid	How did John Quincy Adams die?	stroke|cerebral hemorrhage
-2100	factoid	What did Caesar say before he died?	Et tu, Brute\?|Brutus
+1446	factoid	How did Mahatma Gandhi die?	\bshot\b|\bshooting\b|\bAssassination\b
+2328	factoid	What state was Amelia Earhart born in?	\bKan(sas|.)\b
+1934	factoid	What is the play "West Side Story" based on?	\bRomeo and Juliet\b|\ba 1961 American romantic musical drama film\b
+1407	factoid	When did the shootings at Columbine happen?	\bApril 20\s?, 1999\b|\b1999\b|\bApril 20\b
+2339	factoid	How did John Quincy Adams die?	\bstroke\b|\bcerebral hemorrhage\b
+2100	factoid	What did Caesar say before he died?	\bEt tu, Brute\?\b|\bBrutus\b
 10076	factoid	what is the lowest prime number?	\b2\b
-2377	factoid	What country is the leading producer of rubber?	Thailand
-2090	factoid	What Ridley Scott movie is set in 180 a.d.?	Gladiator
-1654	factoid	Where is Prairie View A&M University?	Texas|United States
-1613	factoid	When was Benjamin Disraeli prime minister?	1868|1874|1880
-10051	factoid	Who wrote Pirate Jenny?	Weill|Bertolt Brecht
-1785	factoid	What body of water does the Euphrates River empty into?	Persian gulf|Shatt al\-Arab
-1932	factoid	When did International Volunteers Day begin?	1985|\(December 5\)
-1438	factoid	What body of water does the Colorado River flow into?	Gulf of California
-2003	factoid	How far is the distance for a free throw?	(15|19)\s*f(oo|ee)?t|(4.6|5.8)\s*m
-1971	factoid	What city is the Liberty Bell currently located in?	Philadelphia
-1541	factoid	What president is on a quarter?	Washington
-1872	factoid	How did Eva Peron die?	cervical cancer|Cancer
-1692	factoid	How tall is the Eiffel Tower in France?	98(4|6)\s?-?\s?f(ee|oo)?t\.?|301\s*m|300m|300 m
-1552	factoid	What did Charles Babbage invent?	Analytic(al)? Engine|computer
-2065	factoid	What is a female moose called?	cows?|Female moose \(called
-1659	factoid	Where was Bob Dylan born?	Duluth\s?, Minn(\.,?|esota)?|Duluth|Minnesota
-1584	factoid	When did George W. Bush get elected as the governor of Texas?	199(4|8)|1995
-2012	factoid	How did Marty Robbins die?	heart attack|cardiac|Surgical complications
-1567	factoid	When did the Black Panther party start in California?	1966
-2265	factoid	How did Marjorie Kinnan Rawlings die?	cerebral hemorrhage
-1702	factoid	Whose business slogan is "Quality is job 1"?	Ford
-2070	factoid	What date did the U.S. civil war start?	April 12.*1861|1861
-1505	factoid	What is the currency used in China?	RMB|Ren?minbi|Yuan
-1935	factoid	What color is the top stripe on the U.S. flag?	red( stripe| color)?$
-1806	factoid	When was the first heart transplant?	1967
-1819	factoid	When did Marilyn Monroe commit suicide?	1962
-10005	factoid	How many pieces are there in a dozen?	\b12\b|twelve
-2086	factoid	What is the study of ants called?	myrmecology
-1799	factoid	What is the life expectancy of the average woman in Nigeria?	5[0-9] years
-1763	factoid	How old is the universe?	1[34].* billion years
-10009	factoid	What color is the sky?	blue
-2105	factoid	What country produces the most silk?	China
-2272	factoid	How many intelligence agencies does the U.S. have?	17
-1714	factoid	What province in Canada is Niagara Falls located in?	Ontario
-1592	factoid	When was the Reichstag burned down?	1933
-1865	factoid	What is the major crop grown in Arizona?	cotton
-1828	factoid	What was Thailand's original name?	Siam|3\:1 THAILAND
-10020	factoid	What is the color of pee?	yellow|golden
-1789	factoid	What is the date of the Kent State Shooting?	May 4\s?, 1970|1970|May 4
-1848	factoid	What was the name of the plane that dropped the Atomic Bomb on Hiroshima?	Enola Gay
-1927	factoid	How did George Washington die?	inflammatory quinsy|severe infection of the throat|throat infection|cynanche trachealis|inflammation|blee?d|epiglottitis
-1534	factoid	The sun is mostly made up of what two gasses?	hydrogen .*helium
-1598	factoid	Who was the baseball player given the nickname "Mr. October"?	Reggie Jackson
-2071	factoid	How many islands are there in Indonesia?	1[78],?(508|306|000)|8,?844
-2029	factoid	How many electoral votes does Tennessee have?	11
-1462	factoid	Where is the oldest synagogue in the United States?	Newport|New York|Rhode Island
-2290	factoid	When was the piano made?	1700|1698|1[78].*century|1993
+2377	factoid	What country is the leading producer of rubber?	\bThailand\b
+2090	factoid	What Ridley Scott movie is set in 180 a.d.?	\bGladiator\b
+1654	factoid	Where is Prairie View A&M University?	\bTexas\b|\bUnited States\b
+1613	factoid	When was Benjamin Disraeli prime minister?	\b1868\b|\b1874\b|\b1880\b
+10051	factoid	Who wrote Pirate Jenny?	\bWeill\b|\bBertolt Brecht\b
+1785	factoid	What body of water does the Euphrates River empty into?	\bPersian gulf\b|\bShatt al\-Arab\b
+1932	factoid	When did International Volunteers Day begin?	\b1985\b|\b\(December 5\)\b
+1438	factoid	What body of water does the Colorado River flow into?	\bGulf of California\b
+2003	factoid	How far is the distance for a free throw?	\b(15|19)\s*f(oo|ee)?t\b|\b(4.6|5.8)\s*m\b
+1971	factoid	What city is the Liberty Bell currently located in?	\bPhiladelphia\b
+1541	factoid	What president is on a quarter?	\bWashington\b
+1872	factoid	How did Eva Peron die?	\bcervical cancer\b|\bCancer\b
+1692	factoid	How tall is the Eiffel Tower in France?	\b98(4|6)\s?-?\s?f(ee|oo)?t\.?\b|\b301\s*m\b|\b300m\b|\b300 m\b
+1552	factoid	What did Charles Babbage invent?	\bAnalytic(al)? Engine\b|\bcomputer\b
+2065	factoid	What is a female moose called?	\bcows?\b|\bFemale moose \(called\b
+1659	factoid	Where was Bob Dylan born?	\bDuluth\s?, Minn(\.,?|esota)?\b|\bDuluth\b|\bMinnesota\b
+1584	factoid	When did George W. Bush get elected as the governor of Texas?	\b199(4|8)\b|\b1995\b
+2012	factoid	How did Marty Robbins die?	\bheart attack\b|\bcardiac\b|\bSurgical complications\b
+1567	factoid	When did the Black Panther party start in California?	\b1966\b
+2265	factoid	How did Marjorie Kinnan Rawlings die?	\bcerebral hemorrhage\b
+1702	factoid	Whose business slogan is "Quality is job 1"?	\bFord\b
+2070	factoid	What date did the U.S. civil war start?	\bApril 12.*1861\b|\b1861\b
+1505	factoid	What is the currency used in China?	\bRMB\b|\bRen?minbi\b|\bYuan\b
+1935	factoid	What color is the top stripe on the U.S. flag?	\bred( stripe| color)?$\b
+1806	factoid	When was the first heart transplant?	\b1967\b
+1819	factoid	When did Marilyn Monroe commit suicide?	\b1962\b
+10005	factoid	How many pieces are there in a dozen?	\b12\b|\btwelve\b
+2086	factoid	What is the study of ants called?	\bmyrmecology\b
+1799	factoid	What is the life expectancy of the average woman in Nigeria?	\b5[0-9] years\b
+1763	factoid	How old is the universe?	\b1[34].* billion years\b
+10009	factoid	What color is the sky?	\bblue\b
+2105	factoid	What country produces the most silk?	\bChina\b
+2272	factoid	How many intelligence agencies does the U.S. have?	\b17\b
+1714	factoid	What province in Canada is Niagara Falls located in?	\bOntario\b
+1592	factoid	When was the Reichstag burned down?	\b1933\b
+1865	factoid	What is the major crop grown in Arizona?	\bcotton\b
+1828	factoid	What was Thailand's original name?	\bSiam\b|\b3\:1 THAILAND\b
+10020	factoid	What is the color of pee?	\byellow\b|\bgolden\b
+1789	factoid	What is the date of the Kent State Shooting?	\bMay 4\s?, 1970\b|\b1970\b|\bMay 4\b
+1848	factoid	What was the name of the plane that dropped the Atomic Bomb on Hiroshima?	\bEnola Gay\b
+1927	factoid	How did George Washington die?	\binflammatory quinsy\b|\bsevere infection of the throat\b|\bthroat infection\b|\bcynanche trachealis\b|\binflammation\b|\bblee?d\b|\bepiglottitis\b
+1534	factoid	The sun is mostly made up of what two gasses?	\bhydrogen .*helium\b
+1598	factoid	Who was the baseball player given the nickname "Mr. October"?	\bReggie Jackson\b
+2071	factoid	How many islands are there in Indonesia?	\b1[78],?(508|306|000)\b|\b8,?844\b
+2029	factoid	How many electoral votes does Tennessee have?	\b11\b
+1462	factoid	Where is the oldest synagogue in the United States?	\bNewport\b|\bNew York\b|\bRhode Island\b
+2290	factoid	When was the piano made?	\b1700\b|\b1698\b|\b1[78].*century\b|\b1993\b
 10066	factoid	in which country was google founded?	\bU(nited|\.)?\s*S(tates|\.)?\b
 2160	factoid	What is the body temperature of a dog?	\b(100|102|38|39)\b
-10044	factoid	Who discovered the structure of DNA?	((Watson|Crick).*){2}|Crick|Watson
-2387	factoid	What country celebrates Guy Fawkes Day?	England|\bGB\b|Great Britain|\bUK\b|United Kingdom
-2218	factoid	What company manufactures Van Heusen shirts?	Phillips-Van Heusen|PVH
-1708	factoid	When was the Exxon Valdez Oil spill?	1989
-1460	factoid	What was the name of the dog in the Thin Man movies?	Asta
-1898	factoid	What city is Disneyland in?	Anaheim|Paris|To(ky|yk)o
-2282	factoid	What canal is between the Mediterranean Sea and the Red Sea?	Suez
-1829	factoid	How tall is the CNN Tower in Toronto?	553.*\s*m|1,?815.*\s*f(oo|ee)?t
-1508	factoid	What was Dale Evans' horse's name?	Buttermilk
-1653	factoid	How do you say "French fries" in French?	pommes frites|frites
-1837	factoid	What year was Ebbets Field, home of Brooklyn Dodgers, built?	191[23]
-1479	factoid	Who composed "The Messiah"?	Handel
-2227	factoid	What is the Bluegrass state?	K(entuck)?y.?
-2231	factoid	What is a word spelled the same backward and forward called?	palindrome
-1710	factoid	What are the colors of the Italian flag?	((green|white|red)\s*,?\s*(and)?\s*){3}
-2330	factoid	What river is under New York's George Washington bridge?	Hudson
-2015	factoid	What building is the Academy of Country Music Awards held in?	MGM Grand Garden Arena|ACM
-10093	factoid	where is kiev ?	Ukraine|\bUA\b
-10029	factoid	What is the proton number of neon?	\b10\b|ten
-1569	factoid	When did the Vietnam War end?	(25|twenty-five) years ago|1975|1973
-2022	factoid	What English city does the prime meridian pass through?	Greenwich
-2088	factoid	How many rooms are in the White House?	132
-10097	factoid	which natural number immediately follows 41 and precedes 43?	\b42\b|fourty.?two
-1537	factoid	How many electoral college votes in Tennessee?	11
-1614	factoid	What is the capital of Victoria?	Melbourne
-1948	factoid	What is the word which means one hiring his relatives?	nepotism
-1436	factoid	What was the name of Stonewall Jackson's horse?	Little Sorrel
-1650	factoid	What county is Elmira, NY in?	Chemung
-1481	factoid	What is the capital city of Algeria?	Algiers
-2017	factoid	What US state produces most of the nation's cheese?	Wisconsin
-2237	factoid	What album became the greatest selling album of all time?	Thriller
-10082	factoid	what is the name of the ninth episode of the seventh season of the animated television series Family Guy?	The Juice is Loose
-2176	factoid	when was Dante's "Inferno" written?	1300s|1308|1321|14th century
-1682	factoid	When was Martin Luther King Jr. born?	Jan(\s?\.?|uary)? 15\s?, 1929|1929
-2134	factoid	What is Motley Crue's Nikki Sixx's real name?	Frank.*Feranna
-1425	factoid	What is the population of Maryland as of 2013?	(5.9|6) million|5,?928,?814|5\.939 million
-1690	factoid	What does DEA stand for?	Drug Enforcement A(dministration|gency)
-1967	factoid	What party led Australia from 1983 to 1996?	ALP|Labor
-10031	factoid	When did Maria Theresa die?	1780
-1976	factoid	What is the motto for the Boy Scouts?	Be Prepared
-1866	factoid	What part of the eye continues to grow throughout a person's life?	lens
-2173	factoid	What is the "Playboy" logo?	bunny|rabbit
-1476	factoid	Who was the Roman god of the sea?	Neptune
-1500	factoid	Where is Georgetown University?	Washington,?
-1764	factoid	What Cuban dictator did Fidel Castro force out of power in 1958?	Batista
-2099	factoid	What comedy team was John Cleese part of?	Monty Python('s)?
-1546	factoid	What year was the movie "Ole Yeller" made?	1957
-1729	factoid	What is the name of the airport in Amsterdam?	Schiph?ol
-1844	factoid	When was the Hellenistic Age?	2nd century B.C.|2nd century B.C.|323(-58)? B.C.
-1769	factoid	Who is the owner of the St. Petersburg Times?	Poynter|Times Publishing
-1980	factoid	How far is the moon from Earth in miles?	221,456( miles?)|221,662|222,000 miles|250 , 000 miles|252,711 miles|238,?900
-2334	factoid	What did Peter Minuit buy for the equivalent of $24.00?	Manhattan
-2033	factoid	How many types of human blood are there?	four|\b4\b|eight|\b8\b|\b33\b
-1834	factoid	Which disciple received 30 pieces of silver for betraying Jesus?	Judas
-1919	factoid	How big is Mars?	diameter.*(4,?21[0-9]\s*miles|6[78][0-9][0-9]\s*(km|kilometers))|radius.*(2,?106\s*miles|3,?390\s*(km|kilometers))|3390km|3390 km|3\,389\.5 km
-1405	factoid	How many ounces are in a gallon?	128
-1815	factoid	What is Nicaragua's main industry?	tourism
-2098	factoid	What player has been the home run champion of the national league seven times?	Kiner
-1867	factoid	Which Italian city is home to the Cathedral of Santa Maria del Fiore or the Duomo?	Florence
-1540	factoid	What is the deepest lake in America?	Crater|Great Slave
-1441	factoid	What is the coldest place on earth?	Antarctica?|South Pole|Vostok Station
-1643	factoid	Who founded Rhode Island?	Roger Williams|Williams
-2068	factoid	What animal is responsible for the most human deaths worldwide?	mosquito
-2056	factoid	What band did former Red Hot Chili Peppers guitarist Dave Navarro start out with?	Jane's Addiction
-1416	factoid	When was Wendy's founded?	1969
-2239	factoid	What prison is Charles Manson at?	Corcoran
-1568	factoid	How old was George Washington when he died?	67
-2064	factoid	What country is Mt. Everest in?	Nepal
-1801	factoid	Where is the smallest bone in the body?	ear
-2117	factoid	What college did Marcus Camby play for?	University of Massachusetts
-1473	factoid	When was Lyndon B. Johnson born?	1908
-1513	factoid	What is the current population in Bombay, India as of 2011?	12(.[45])? million|18(.4)? million|20(.7)? million|12,478,447|18,414,288|12\,442\,373
-1820	factoid	When is Mexico's independence?	18(10|21)
-1759	factoid	Who wrote "Fiddler on the Roof?"	Sheldon Harnick
-1618	factoid	Where is bile produced?	liver
-1949	factoid	What is the nickname of the British flag?	Union Jacks?
-1674	factoid	What day did Neil Armstrong land on the moon?	July 20\s?, 1969
-2197	factoid	What is the name of the first unmanned space craft sent to Mars by NASA?	Viking
-2191	factoid	What city is the gateway arch located in?	St.*?Louis
-10013	factoid	What does Tardis stand for?	Time and Relative Dimension in Space
-1475	factoid	Who was the first person to reach the south pole?	Amundsen
-10038	factoid	When was Watt's steam engine invented?	1765|177[46]|1763 to 1775
-1429	factoid	What was Andrew Jackson's wife's name?	Rachel
-1626	factoid	What is Buzz Aldrin's real first name?	Edwin
-2055	factoid	What dessert is made with poached peach halves, vanilla ice cream, and raspberry sauce?	PEACH MELBA
-2266	factoid	What substance did Charles Best and Frederick Banting discover in 1922?	insulin
-1600	factoid	What automobile company makes the Spider?	Alfa Romeo|Fiat
-1604	factoid	What does R&B stand for?	rhythm and blues
-10021	factoid	What is the critical mass of Plutonium?	\b(9|10)(\.[0-9]*)?\s*k(ilo)?g|11 kg \(24\.2 lbs\)\, 10\.2 cm \(4\"\) in diameter\.
-1849	factoid	What is the nickname of Oklahoma?	Sooners?( State)?
-1636	factoid	When was the battle of Chancellorsville fought?	1863|April 30
-1861	factoid	Where was Bill Gates born?	Seattle|Washington|United States of America
-2037	factoid	How did Iowa get its name?	(Siouan|indian).*(ayuhwa|ouaouia|asleep)|the Ioway people|named after the Iowa River\, which was named for the Ioway natives living at its banks\.|The state of Iowa\, originally a territory of Wisconsin west of the Mississippi River\, was named after the Iowa River\.
-10046	factoid	Who is author of cryptonomicon?	Stephenson
-1711	factoid	When was the first jet invented?	1928
-2057	factoid	How many children did Bob Marley have?	seven|\b7\b|11
-1870	factoid	What country is Pretoria in?	South(\s|_)African?
-1982	factoid	What movie won the Academy Award for best picture in 1989?	Driving Miss Daisy
-2189	factoid	What animal can go the longest without water?	kangaroo rat|Giraffe
-2010	factoid	What island was Napoleon exiled to after his defeat at Waterloo?	(St\.?|Saint) Helena
-10012	factoid	What did James Watson and Francis Crick discover?	DNA|deoxyribonucleic
-1539	factoid	What is Ronald Reagan's favorite candy?	Jelly Belly|jelly\s?beans?
-2038	factoid	What did Alfred Noble invent?	dynamite
-1660	factoid	What is Elvis Presley's middle name?	Aa?ron
-2075	factoid	What city in Louisiana was Britney Spears born in?	Kentwood
-2120	factoid	What does "CBS" (television network) stand for?	Columbia Broadcasting System
-1532	factoid	What is the literacy rate in Cuba?	99.8\s*(percent|%)|97\%
-1985	factoid	What is the Cav's arena name?	Gund|Quicken Loans
-1926	factoid	When was the U.S. capitol built?	179[03-9]|1800
-1776	factoid	What year did the first American lighthouse open?	1716
-1906	factoid	How did the disciple Peter die?	crucif.*
-1890	factoid	Who is the author of the poem "The Midnight Ride of Paul Revere?"	Longfellow
-2263	factoid	How big was the Super Big Gulp sold in 7-Eleven stores in 1980?	1.2\s*l|41.*(fl oz|ounces)
-10065	factoid	how much is 41+1?	\b42\b|fourty-two
-2233	factoid	How far is a 3-point line from the basketball goal in the NBA?	23\s*(f(ee|oo)?t|').*9\s*(in(ch)?(es)?|")
-10003	factoid	How many children did Maria Theresa have?	sixteen|\b16\b
-1545	factoid	What is a female rabbit called?	doe
-1774	factoid	What does HTML stand for?	hyper\s?text markup language
-10007	factoid	In what city the first nuclear bomb exploded?	Hiroshima
-2230	factoid	What dam is said the be the largest hydroelectric station in the world?	Three Gorges|Itaipu
-2276	factoid	When was Mariah Carey born?	March 27|1969|1970
-2205	factoid	How many cabinet officers are there?	\b(14|15|22|23)\b|the executive branch of the federal government of the United States\, who are
-2354	factoid	How did Anne Frank die?	typhus|concentration camp
-1998	factoid	How old was Babe Ruth when he died?	53
-2155	factoid	What country is home to Sabena Airlines?	Belgi(a|u)(m|n)
-1833	factoid	How tall is Mike Tyson?	5\s*(f(ee|oo)?t|')\s*10\s*(in(ch.*)?|")|1\.78|178 cm tall
-2371	factoid	What type of bee drills holes in wood?	carpenter
-1467	factoid	What year did South Dakota become a state?	1889
-1579	factoid	Which country exports the most tea?	Sri Lanka|India|Kenya
-2145	factoid	What does a theodolite measure?	angle
-2032	factoid	What sporting event first took place in 1903?	Tour de France
-1718	factoid	When was the White House built?	1(792|800)
-1635	factoid	What is the name of the famous dogsledding race held each year in Alaska?	Iditarod
-1450	factoid	Which U.S. state is the leading corn producer?	Iowa
-1536	factoid	What city is Lake Washington by?	Seattle
-1482	factoid	What county is Wilmington, Delaware in?	New Castle
-1533	factoid	Who directed the film "Fail Safe"?	Sidney Lumet
-1914	factoid	What city is the home to the Rock and Roll Hall of Fame?	Cleveland
-2223	factoid	When was the first practical camera invented?	1839
-2026	factoid	When was the first Olympics held?	776 BC|-776|1896
-2255	factoid	How do you say "I love you" in French?	je t'aime
-10037	factoid	When was the first commercially successful steam engine invented?	1698|1712
-10059	factoid	how long is the day?	24\s*h|86,?400\s*s
-1683	factoid	What name is horror actor William Henry Pratt better known by?	Boris Karloff
-1621	factoid	What is the name of the country in the Pyrenees mountains between France and Spain?	Andorra
-2390	factoid	What ancient tribe of Mexico left behind huge stone heads?	Olmecs?
-2104	factoid	When was the first submarine not using human-powered propulsion invented?	July 1863|1914|1863
-1556	factoid	What cemetery is Thurgood Marshall buried in?	Arlington
-1547	factoid	What is the atomic number of uranium?	92
-10052	factoid	What is the chemical formula of methane?	C.*H.*4
-2052	factoid	What county is San Antonio, Texas in?	Bexar
-1871	factoid	How much gravity exists on Mars?	third|38\s*(%|percent)|3.711.*m/s|0.376\s*g
-1444	factoid	What female leader succeeded Ferdinand Marcos as president of the Philippines?	Corazon Aquino
-2376	factoid	What color belt is first in karate?	white
-1528	factoid	Where did Kublai Khan live?	Beijing|China
-1442	factoid	What is the chemical formula for sulphur dioxide?	SO2|the chemical compound
-1565	factoid	What is Karl Malone's nickname?	The Mailman
-1830	factoid	What city does the Tour de France end in?	Paris
-1419	factoid	What year did Alaska become a state?	1958|1959
-1782	factoid	Who was the first woman to run for president?	Pamfilova|Victoria Woodhull|Woodhull
-2028	factoid	What are the biggest snakes in the world?	anaconda|reticulated python|titanoboa|Gigantophis|Burmese python
-1994	factoid	What was the Beatles' first number one hit?	Please Please Me|From Me To You
-1681	factoid	When did Houdini die?	1926
-10023	factoid	What is the density of water?	\b(1|0\.9.*)\s*g|\b(1,?000|9.*)\s*kg|cubic centimeter|approximately one gram
-1418	factoid	When was the Rosenberg trial?	1951|1953|May 12
-1560	factoid	What was Denzel Washington's first television series?	St. Elsewhere
-1836	factoid	What river runs through Rome, Italy?	Tiber
-1427	factoid	What was the first spaceship on the moon?	Eagle
-2066	factoid	What is tequila made from?	agave
-1688	factoid	What year was the gateway arch built?	1965|1963
-1411	factoid	What Spanish explorer discovered the Mississippi River?	Hernando de Soto
-1811	factoid	When was penicillin first used?	194(0s|1|2|7)|1943|But it was not until 1928 that penicillin\, the first true antibiotic\, was discovered by Alexander Fleming\, Professor of Bacteriology at St\. Mary\'s Hospital in London\.
-2133	factoid	When was Abraham Lincoln born?	1809.*?
-1662	factoid	When was Jerusalem invaded by the general Titus?	70 A.D.|70\s*AD|AD\s*70|A.D.\s*70|70
-1821	factoid	Who was the architect who designed the Empire State Building?	Lamb
-2000	factoid	How many Earth days does it take for Mars to orbit the sun?	68[67]
-2261	factoid	What college did Magic Johnson go to?	Michigan State
-1652	factoid	When did the United States enter World War II?	1941
-1874	factoid	When was the battle of Shiloh?	1862
-1570	factoid	What is the legal age to vote in Argentina?	18
-1991	factoid	How did Minnesota get its name?	Sioux.*river|river.*Sioux
-1839	factoid	What country was formed in 1948?	Burma|Israel|Myanmar
-1397	factoid	What was the largest crowd to ever come see Michael Jordan?	62,?046
-1414	factoid	What was the length of the  Wright brothers' first flight?	120\s?\-?\s?f(ee|oo)?t|852 feet
-2315	factoid	How many tentacles do squids actually have?	two|\b2\b
-1645	factoid	How much is the international space stations expected to cost?	\$ 95 billion|\$60 billion|about \$ 50 billion|more than 100 billion dollar|150\s*(billion|bn)|\$100
-2131	factoid	Who was the first African-American speaker of the California State Assembly?	Brown
-1736	factoid	Where on the body would you find the jowls?	cheek|Face
-1477	factoid	What are wavelengths of visible light measured in?	angstrom|nanometers|^nm
-1824	factoid	Which planet did the spacecraft Magellan enable scientists to research extensively?	Venus
-1855	factoid	How fast is the world spinning?	1,?0[34][0-9]\s*(miles per hour|mph)|1,?6[67][0-9]\s*(kilometers per hour|km.*h)
-2136	factoid	How many moons does Neptune have?	eight|\b8\b|14
-1576	factoid	What galaxy is closest to the milky way?	Andromeda
-1595	factoid	What person developed COBOL?	Hopper
-2122	factoid	What is the inner peel of an orange called?	pith
-1781	factoid	What year did "Snow White" come out?	1937
-1784	factoid	What is the scientific name for leech?	Hirudo medicinalis|Hirudo
-2165	factoid	What date was the Declaration of Independence signed on?	Aug. 2, 1776|July 4.*?1776|July 4
-1637	factoid	What is the name of the five pointed star commonly used by Satanists?	baphomet|pentagrams?|The five point star
-1447	factoid	What is the capital of Syria?	Damascus
-1531	factoid	What does NASDAQ stand for?	National Association of Securities Dealers Automated Quotations?
-10090	factoid	when did vikings colonize greenland?	\b98[0-9]\b|10th century
-2391	factoid	What president created social security?	Roosevelt|FDR
-1480	factoid	What is the principle port in Ecuador?	Guayaquil
-2195	factoid	When was Ronald Reagan shot?	1981
-1488	factoid	What is the name of the professional baseball team in Myrtle Beach, South Carolina?	Pelicans
-2252	factoid	What apostle was crucified?	Peter
-1583	factoid	What is the text of an opera called?	libretto
-10041	factoid	Where was the first of the International Mathematical Olympiads held?	Romania
-1716	factoid	Who was the first Triple Crown Winner?	Sir Barton
-1969	factoid	What does ACLU stand for?	American Civil Liberties Union
-2127	factoid	What country did Panama gain its independence from?	Colombia
-1609	factoid	What is the currency of Bolivia called?	BOB|boliviano
-2337	factoid	How did Joseph Smith die?	mob|assassin|lynch|shoo?t|Murder|Firearm
-2129	factoid	How many home runs did Henry "Hank" Aaron hit in his major league career?	755
-1742	factoid	When did the Mesozoic period end?	6[56] million years ago
-1606	factoid	What is the boiling point of water?	212\s*(.|degrees?)\s*F|100\s*(.|degrees?)\s*C|100 o|101\.325
-2152	factoid	When was the Great Wall of China built?	2,?000 years ago|7th century BC|6.. BC|2[0-2]. BC|Ming
-2102	factoid	What American landmark stands on Liberty Island?	Statue of Liberty
-2289	factoid	What continent is Togo on?	African?
-10071	factoid	what is the answer to ultimate question of life, universe and everything?	\b42\b|fourty-two
-1956	factoid	What country is the largest in square miles?	Russia
-1983	factoid	When was Lyndon B. Johnson president?	1963.*69
-1916	factoid	What city did Duke Ellington live in?	New York|Washington|North Carolina
-1859	factoid	What branch of the military has its academy in Annapolis?	Nav(al|y)
-1700	factoid	Where is America's Stonehenge?	Mystery Hill|N.H.|Salem(, New Hampshire)?|South of Manchester
-2295	factoid	What 1857 U.S. Supreme Court decision denied that blacks were citizens?	Dred Scott|Supreme Court
-1713	factoid	What is the name of the phobia for number 13?	Triskaidekaphobia
-1856	factoid	What city is known as the rubber capital of the world?	Akron,?
-2121	factoid	What artist recorded the song "At Last" in the 40's or 50's?	Etta James
-10057	factoid	how long are spaghetti?	(25|30|50)\s*c(enti)?m|(10|12|20)\s*("|in)
-1615	factoid	What is Africa's largest country?	Sudan|Algeria|Nigeria
-10099	factoid	who are the inventors of the first transistor?	((Bardeen|Shockley|Brattain).*){3}|Bardeen|Shockley|Brattain
-10010	factoid	What currency is used in Christiania?	L[oø]n
-1911	factoid	What is the name of the chart that tells you the symbol for all chemical elements?	periodic (table|chart)
-10094	factoid	where was jesus born?,	Bethlehem
-10109	factoid	who wrote ender's game?	Orson.*Card
-1496	factoid	What country is Berlin in?	Germany
-1464	factoid	Who is the detective on "Diagnosis Murder"?	Steve Sloan
-1640	factoid	Who founded Taoism?	Lao\s*-?\s*T[zs][ue]|Laozi
-1843	factoid	In what month are the most babies born?	July|August|September
-1669	factoid	How tall is Mount McKinley?	20\s?,?\s?(32|40)0\s?-?\s?f(ee|oo)t|6,194-meter|20,?237\s*f(oo|ee)?t|20,?073\s*f(oo|ee)?t|6,?168\s*m|6,118\s*m|6\,194 m|20\,322 feet
-2388	factoid	what Arthur Miller play recounts his marriage to Marilyn Monroe?	After the Fall|Finishing the Play
-1544	factoid	What is the most populated country in the world?	China
-1783	factoid	What country are Volvo automobiles made in?	Sweden
+10044	factoid	Who discovered the structure of DNA?	\b((Watson|Crick).*){2}\b|\bCrick\b|\bWatson\b
+2387	factoid	What country celebrates Guy Fawkes Day?	\bEngland\b|\bGB\b|\bGreat Britain\b|\bUK\b|\bUnited Kingdom\b
+2218	factoid	What company manufactures Van Heusen shirts?	\bPhillips-Van Heusen\b|\bPVH\b
+1708	factoid	When was the Exxon Valdez Oil spill?	\b1989\b
+1460	factoid	What was the name of the dog in the Thin Man movies?	\bAsta\b
+1898	factoid	What city is Disneyland in?	\bAnaheim\b|\bParis\b|\bTo(ky|yk)o\b
+2282	factoid	What canal is between the Mediterranean Sea and the Red Sea?	\bSuez\b
+1829	factoid	How tall is the CNN Tower in Toronto?	\b553.*\s*m\b|\b1,?815.*\s*f(oo|ee)?t\b
+1508	factoid	What was Dale Evans' horse's name?	\bButtermilk\b
+1653	factoid	How do you say "French fries" in French?	\bpommes frites\b|\bfrites\b
+1837	factoid	What year was Ebbets Field, home of Brooklyn Dodgers, built?	\b191[23]\b
+1479	factoid	Who composed "The Messiah"?	\bHandel\b
+2227	factoid	What is the Bluegrass state?	\bK(entuck)?y.?\b
+2231	factoid	What is a word spelled the same backward and forward called?	\bpalindrome\b
+1710	factoid	What are the colors of the Italian flag?	\b((green|white|red)\s*,?\s*(and)?\s*){3}\b
+2330	factoid	What river is under New York's George Washington bridge?	\bHudson\b
+2015	factoid	What building is the Academy of Country Music Awards held in?	\bMGM Grand Garden Arena\b|\bACM\b
+10093	factoid	where is kiev ?	\bUkraine\b|\bUA\b
+10029	factoid	What is the proton number of neon?	\b10\b|\bten\b
+1569	factoid	When did the Vietnam War end?	\b(25|twenty-five) years ago\b|\b1975\b|\b1973\b
+2022	factoid	What English city does the prime meridian pass through?	\bGreenwich\b
+2088	factoid	How many rooms are in the White House?	\b132\b
+10097	factoid	which natural number immediately follows 41 and precedes 43?	\b42\b|\bfourty.?two\b
+1537	factoid	How many electoral college votes in Tennessee?	\b11\b
+1614	factoid	What is the capital of Victoria?	\bMelbourne\b
+1948	factoid	What is the word which means one hiring his relatives?	\bnepotism\b
+1436	factoid	What was the name of Stonewall Jackson's horse?	\bLittle Sorrel\b
+1650	factoid	What county is Elmira, NY in?	\bChemung\b
+1481	factoid	What is the capital city of Algeria?	\bAlgiers\b
+2017	factoid	What US state produces most of the nation's cheese?	\bWisconsin\b
+2237	factoid	What album became the greatest selling album of all time?	\bThriller\b
+10082	factoid	what is the name of the ninth episode of the seventh season of the animated television series Family Guy?	\bThe Juice is Loose\b
+2176	factoid	when was Dante's "Inferno" written?	\b1300s\b|\b1308\b|\b1321\b|\b14th century\b
+1682	factoid	When was Martin Luther King Jr. born?	\bJan(\s?\.?|uary)? 15\s?, 1929\b|\b1929\b
+2134	factoid	What is Motley Crue's Nikki Sixx's real name?	\bFrank.*Feranna\b
+1425	factoid	What is the population of Maryland as of 2013?	\b(5.9|6) million\b|\b5,?928,?814\b|\b5\.939 million\b
+1690	factoid	What does DEA stand for?	\bDrug Enforcement A(dministration|gency)\b
+1967	factoid	What party led Australia from 1983 to 1996?	\bALP\b|\bLabor\b
+10031	factoid	When did Maria Theresa die?	\b1780\b
+1976	factoid	What is the motto for the Boy Scouts?	\bBe Prepared\b
+1866	factoid	What part of the eye continues to grow throughout a person's life?	\blens\b
+2173	factoid	What is the "Playboy" logo?	\bbunny\b|\brabbit\b
+1476	factoid	Who was the Roman god of the sea?	\bNeptune\b
+1500	factoid	Where is Georgetown University?	\bWashington,?\b
+1764	factoid	What Cuban dictator did Fidel Castro force out of power in 1958?	\bBatista\b
+2099	factoid	What comedy team was John Cleese part of?	\bMonty Python('s)?\b
+1546	factoid	What year was the movie "Ole Yeller" made?	\b1957\b
+1729	factoid	What is the name of the airport in Amsterdam?	\bSchiph?ol\b
+1844	factoid	When was the Hellenistic Age?	\b2nd century B.C.\b|\b2nd century B.C.\b|\b323(-58)? B.C.\b
+1769	factoid	Who is the owner of the St. Petersburg Times?	\bPoynter\b|\bTimes Publishing\b
+1980	factoid	How far is the moon from Earth in miles?	\b221,456( miles?)\b|\b221,662\b|\b222,000 miles\b|\b250 , 000 miles\b|\b252,711 miles\b|\b238,?900\b
+2334	factoid	What did Peter Minuit buy for the equivalent of $24.00?	\bManhattan\b
+2033	factoid	How many types of human blood are there?	\bfour\b|\b4\b|\beight\b|\b8\b|\b33\b
+1834	factoid	Which disciple received 30 pieces of silver for betraying Jesus?	\bJudas\b
+1919	factoid	How big is Mars?	\bdiameter.*(4,?21[0-9]\s*miles|6[78][0-9][0-9]\s*(km|kilometers))\b|\bradius.*(2,?106\s*miles|3,?390\s*(km|kilometers))\b|\b3390km\b|\b3390 km\b|\b3\,389\.5 km\b
+1405	factoid	How many ounces are in a gallon?	\b128\b
+1815	factoid	What is Nicaragua's main industry?	\btourism\b
+2098	factoid	What player has been the home run champion of the national league seven times?	\bKiner\b
+1867	factoid	Which Italian city is home to the Cathedral of Santa Maria del Fiore or the Duomo?	\bFlorence\b
+1540	factoid	What is the deepest lake in America?	\bCrater\b|\bGreat Slave\b
+1441	factoid	What is the coldest place on earth?	\bAntarctica?\b|\bSouth Pole\b|\bVostok Station\b
+1643	factoid	Who founded Rhode Island?	\bRoger Williams\b|\bWilliams\b
+2068	factoid	What animal is responsible for the most human deaths worldwide?	\bmosquito\b
+2056	factoid	What band did former Red Hot Chili Peppers guitarist Dave Navarro start out with?	\bJane's Addiction\b
+1416	factoid	When was Wendy's founded?	\b1969\b
+2239	factoid	What prison is Charles Manson at?	\bCorcoran\b
+1568	factoid	How old was George Washington when he died?	\b67\b
+2064	factoid	What country is Mt. Everest in?	\bNepal\b
+1801	factoid	Where is the smallest bone in the body?	\bear\b
+2117	factoid	What college did Marcus Camby play for?	\bUniversity of Massachusetts\b
+1473	factoid	When was Lyndon B. Johnson born?	\b1908\b
+1513	factoid	What is the current population in Bombay, India as of 2011?	\b12(.[45])? million\b|\b18(.4)? million\b|\b20(.7)? million\b|\b12,478,447\b|\b18,414,288\b|\b12\,442\,373\b
+1820	factoid	When is Mexico's independence?	\b18(10|21)\b
+1759	factoid	Who wrote "Fiddler on the Roof?"	\bSheldon Harnick\b
+1618	factoid	Where is bile produced?	\bliver\b
+1949	factoid	What is the nickname of the British flag?	\bUnion Jacks?\b
+1674	factoid	What day did Neil Armstrong land on the moon?	\bJuly 20\s?, 1969\b
+2197	factoid	What is the name of the first unmanned space craft sent to Mars by NASA?	\bViking\b
+2191	factoid	What city is the gateway arch located in?	\bSt.*?Louis\b
+10013	factoid	What does Tardis stand for?	\bTime and Relative Dimension in Space\b
+1475	factoid	Who was the first person to reach the south pole?	\bAmundsen\b
+10038	factoid	When was Watt's steam engine invented?	\b1765\b|\b177[46]\b|\b1763 to 1775\b
+1429	factoid	What was Andrew Jackson's wife's name?	\bRachel\b
+1626	factoid	What is Buzz Aldrin's real first name?	\bEdwin\b
+2055	factoid	What dessert is made with poached peach halves, vanilla ice cream, and raspberry sauce?	\bPEACH MELBA\b
+2266	factoid	What substance did Charles Best and Frederick Banting discover in 1922?	\binsulin\b
+1600	factoid	What automobile company makes the Spider?	\bAlfa Romeo\b|\bFiat\b
+1604	factoid	What does R&B stand for?	\brhythm and blues\b
+10021	factoid	What is the critical mass of Plutonium?	\b(9|10)(\.[0-9]*)?\s*k(ilo)?g\b|\b11 kg \(24\.2 lbs\)\, 10\.2 cm \(4\"\) in diameter\.\b
+1849	factoid	What is the nickname of Oklahoma?	\bSooners?( State)?\b
+1636	factoid	When was the battle of Chancellorsville fought?	\b1863\b|\bApril 30\b
+1861	factoid	Where was Bill Gates born?	\bSeattle\b|\bWashington\b|\bUnited States of America\b
+2037	factoid	How did Iowa get its name?	\b(Siouan|indian).*(ayuhwa|ouaouia|asleep)\b|\bthe Ioway people\b|\bnamed after the Iowa River\, which was named for the Ioway natives living at its banks\.\b|\bThe state of Iowa\, originally a territory of Wisconsin west of the Mississippi River\, was named after the Iowa River\.\b
+10046	factoid	Who is author of cryptonomicon?	\bStephenson\b
+1711	factoid	When was the first jet invented?	\b1928\b
+2057	factoid	How many children did Bob Marley have?	\bseven\b|\b7\b|\b11\b
+1870	factoid	What country is Pretoria in?	\bSouth(\s|_)African?\b
+1982	factoid	What movie won the Academy Award for best picture in 1989?	\bDriving Miss Daisy\b
+2189	factoid	What animal can go the longest without water?	\bkangaroo rat\b|\bGiraffe\b
+2010	factoid	What island was Napoleon exiled to after his defeat at Waterloo?	\b(St\.?|Saint) Helena\b
+10012	factoid	What did James Watson and Francis Crick discover?	\bDNA\b|\bdeoxyribonucleic\b
+1539	factoid	What is Ronald Reagan's favorite candy?	\bJelly Belly\b|\bjelly\s?beans?\b
+2038	factoid	What did Alfred Noble invent?	\bdynamite\b
+1660	factoid	What is Elvis Presley's middle name?	\bAa?ron\b
+2075	factoid	What city in Louisiana was Britney Spears born in?	\bKentwood\b
+2120	factoid	What does "CBS" (television network) stand for?	\bColumbia Broadcasting System\b
+1532	factoid	What is the literacy rate in Cuba?	\b99.8\s*(percent|%)\b|\b97\%\b
+1985	factoid	What is the Cav's arena name?	\bGund\b|\bQuicken Loans\b
+1926	factoid	When was the U.S. capitol built?	\b179[03-9]\b|\b1800\b
+1776	factoid	What year did the first American lighthouse open?	\b1716\b
+1906	factoid	How did the disciple Peter die?	\bcrucif.*\b
+1890	factoid	Who is the author of the poem "The Midnight Ride of Paul Revere?"	\bLongfellow\b
+2263	factoid	How big was the Super Big Gulp sold in 7-Eleven stores in 1980?	\b1.2\s*l\b|\b41.*(fl oz|ounces)\b
+10065	factoid	how much is 41+1?	\b42\b|\bfourty-two\b
+2233	factoid	How far is a 3-point line from the basketball goal in the NBA?	\b23\s*(f(ee|oo)?t\b|\b').*9\s*(in(ch)?(es)?\b|\b")\b
+10003	factoid	How many children did Maria Theresa have?	\bsixteen\b|\b16\b
+1545	factoid	What is a female rabbit called?	\bdoe\b
+1774	factoid	What does HTML stand for?	\bhyper\s?text markup language\b
+10007	factoid	In what city the first nuclear bomb exploded?	\bHiroshima\b
+2230	factoid	What dam is said the be the largest hydroelectric station in the world?	\bThree Gorges\b|\bItaipu\b
+2276	factoid	When was Mariah Carey born?	\bMarch 27\b|\b1969\b|\b1970\b
+2205	factoid	How many cabinet officers are there?	\b(14|15|22|23)\b|\bthe executive branch of the federal government of the United States\, who are\b
+2354	factoid	How did Anne Frank die?	\btyphus\b|\bconcentration camp\b
+1998	factoid	How old was Babe Ruth when he died?	\b53\b
+2155	factoid	What country is home to Sabena Airlines?	\bBelgi(a|u)(m|n)\b
+1833	factoid	How tall is Mike Tyson?	\b5\s*(f(ee|oo)?t\b|\b')\s*10\s*(in(ch.*)?\b|\b")\b|\b1\.78\b|\b178 cm tall\b
+2371	factoid	What type of bee drills holes in wood?	\bcarpenter\b
+1467	factoid	What year did South Dakota become a state?	\b1889\b
+1579	factoid	Which country exports the most tea?	\bSri Lanka\b|\bIndia\b|\bKenya\b
+2145	factoid	What does a theodolite measure?	\bangle\b
+2032	factoid	What sporting event first took place in 1903?	\bTour de France\b
+1718	factoid	When was the White House built?	\b1(792|800)\b
+1635	factoid	What is the name of the famous dogsledding race held each year in Alaska?	\bIditarod\b
+1450	factoid	Which U.S. state is the leading corn producer?	\bIowa\b
+1536	factoid	What city is Lake Washington by?	\bSeattle\b
+1482	factoid	What county is Wilmington, Delaware in?	\bNew Castle\b
+1533	factoid	Who directed the film "Fail Safe"?	\bSidney Lumet\b
+1914	factoid	What city is the home to the Rock and Roll Hall of Fame?	\bCleveland\b
+2223	factoid	When was the first practical camera invented?	\b1839\b
+2026	factoid	When was the first Olympics held?	\b776 BC\b|\b-776\b|\b1896\b
+2255	factoid	How do you say "I love you" in French?	\bje t'aime\b
+10037	factoid	When was the first commercially successful steam engine invented?	\b1698\b|\b1712\b
+10059	factoid	how long is the day?	\b24\s*h\b|\b86,?400\s*s\b
+1683	factoid	What name is horror actor William Henry Pratt better known by?	\bBoris Karloff\b
+1621	factoid	What is the name of the country in the Pyrenees mountains between France and Spain?	\bAndorra\b
+2390	factoid	What ancient tribe of Mexico left behind huge stone heads?	\bOlmecs?\b
+2104	factoid	When was the first submarine not using human-powered propulsion invented?	\bJuly 1863\b|\b1914\b|\b1863\b
+1556	factoid	What cemetery is Thurgood Marshall buried in?	\bArlington\b
+1547	factoid	What is the atomic number of uranium?	\b92\b
+10052	factoid	What is the chemical formula of methane?	\bC.*H.*4\b
+2052	factoid	What county is San Antonio, Texas in?	\bBexar\b
+1871	factoid	How much gravity exists on Mars?	\bthird\b|\b38\s*(%|percent)\b|\b3.711.*m/s\b|\b0.376\s*g\b
+1444	factoid	What female leader succeeded Ferdinand Marcos as president of the Philippines?	\bCorazon Aquino\b
+2376	factoid	What color belt is first in karate?	\bwhite\b
+1528	factoid	Where did Kublai Khan live?	\bBeijing\b|\bChina\b
+1442	factoid	What is the chemical formula for sulphur dioxide?	\bSO2\b|\bthe chemical compound\b
+1565	factoid	What is Karl Malone's nickname?	\bThe Mailman\b
+1830	factoid	What city does the Tour de France end in?	\bParis\b
+1419	factoid	What year did Alaska become a state?	\b1958\b|\b1959\b
+1782	factoid	Who was the first woman to run for president?	\bPamfilova\b|\bVictoria Woodhull\b|\bWoodhull\b
+2028	factoid	What are the biggest snakes in the world?	\banaconda\b|\breticulated python\b|\btitanoboa\b|\bGigantophis\b|\bBurmese python\b
+1994	factoid	What was the Beatles' first number one hit?	\bPlease Please Me\b|\bFrom Me To You\b
+1681	factoid	When did Houdini die?	\b1926\b
+10023	factoid	What is the density of water?	\b(1|0\.9.*)\s*g\b|\b(1,?000|9.*)\s*kg\b|\bcubic centimeter\b|\bapproximately one gram\b
+1418	factoid	When was the Rosenberg trial?	\b1951\b|\b1953\b|\bMay 12\b
+1560	factoid	What was Denzel Washington's first television series?	\bSt. Elsewhere\b
+1836	factoid	What river runs through Rome, Italy?	\bTiber\b
+1427	factoid	What was the first spaceship on the moon?	\bEagle\b
+2066	factoid	What is tequila made from?	\bagave\b
+1688	factoid	What year was the gateway arch built?	\b1965\b|\b1963\b
+1411	factoid	What Spanish explorer discovered the Mississippi River?	\bHernando de Soto\b
+1811	factoid	When was penicillin first used?	\b194(0s|1|2|7)\b|\b1943\b|\bBut it was not until 1928 that penicillin\, the first true antibiotic\, was discovered by Alexander Fleming\, Professor of Bacteriology at St\. Mary\'s Hospital in London\.\b
+2133	factoid	When was Abraham Lincoln born?	\b1809.*?\b
+1662	factoid	When was Jerusalem invaded by the general Titus?	\b70 A.D.\b|\b70\s*AD\b|\bAD\s*70\b|\bA.D.\s*70\b|\b70\b
+1821	factoid	Who was the architect who designed the Empire State Building?	\bLamb\b
+2000	factoid	How many Earth days does it take for Mars to orbit the sun?	\b68[67]\b
+2261	factoid	What college did Magic Johnson go to?	\bMichigan State\b
+1652	factoid	When did the United States enter World War II?	\b1941\b
+1874	factoid	When was the battle of Shiloh?	\b1862\b
+1570	factoid	What is the legal age to vote in Argentina?	\b18\b
+1991	factoid	How did Minnesota get its name?	\bSioux.*river\b|\briver.*Sioux\b
+1839	factoid	What country was formed in 1948?	\bBurma\b|\bIsrael\b|\bMyanmar\b
+1397	factoid	What was the largest crowd to ever come see Michael Jordan?	\b62,?046\b
+1414	factoid	What was the length of the  Wright brothers' first flight?	\b120\s?\-?\s?f(ee|oo)?t\b|\b852 feet\b
+2315	factoid	How many tentacles do squids actually have?	\btwo\b|\b2\b
+1645	factoid	How much is the international space stations expected to cost?	\b\$ 95 billion\b|\b\$60 billion\b|\babout \$ 50 billion\b|\bmore than 100 billion dollar\b|\b150\s*(billion|bn)\b|\b\$100\b
+2131	factoid	Who was the first African-American speaker of the California State Assembly?	\bBrown\b
+1736	factoid	Where on the body would you find the jowls?	\bcheek\b|\bFace\b
+1477	factoid	What are wavelengths of visible light measured in?	\bangstrom\b|\bnanometers\b|\b^nm\b
+1824	factoid	Which planet did the spacecraft Magellan enable scientists to research extensively?	\bVenus\b
+1855	factoid	How fast is the world spinning?	\b1,?0[34][0-9]\s*(miles per hour|mph)\b|\b1,?6[67][0-9]\s*(kilometers per hour|km.*h)\b
+2136	factoid	How many moons does Neptune have?	\beight\b|\b8\b|\b14\b
+1576	factoid	What galaxy is closest to the milky way?	\bAndromeda\b
+1595	factoid	What person developed COBOL?	\bHopper\b
+2122	factoid	What is the inner peel of an orange called?	\bpith\b
+1781	factoid	What year did "Snow White" come out?	\b1937\b
+1784	factoid	What is the scientific name for leech?	\bHirudo medicinalis\b|\bHirudo\b
+2165	factoid	What date was the Declaration of Independence signed on?	\bAug. 2, 1776\b|\bJuly 4.*?1776\b|\bJuly 4\b
+1637	factoid	What is the name of the five pointed star commonly used by Satanists?	\bbaphomet\b|\bpentagrams?\b|\bThe five point star\b
+1447	factoid	What is the capital of Syria?	\bDamascus\b
+1531	factoid	What does NASDAQ stand for?	\bNational Association of Securities Dealers Automated Quotations?\b
+10090	factoid	when did vikings colonize greenland?	\b98[0-9]\b|\b10th century\b
+2391	factoid	What president created social security?	\bRoosevelt\b|\bFDR\b
+1480	factoid	What is the principle port in Ecuador?	\bGuayaquil\b
+2195	factoid	When was Ronald Reagan shot?	\b1981\b
+1488	factoid	What is the name of the professional baseball team in Myrtle Beach, South Carolina?	\bPelicans\b
+2252	factoid	What apostle was crucified?	\bPeter\b
+1583	factoid	What is the text of an opera called?	\blibretto\b
+10041	factoid	Where was the first of the International Mathematical Olympiads held?	\bRomania\b
+1716	factoid	Who was the first Triple Crown Winner?	\bSir Barton\b
+1969	factoid	What does ACLU stand for?	\bAmerican Civil Liberties Union\b
+2127	factoid	What country did Panama gain its independence from?	\bColombia\b
+1609	factoid	What is the currency of Bolivia called?	\bBOB\b|\bboliviano\b
+2337	factoid	How did Joseph Smith die?	\bmob\b|\bassassin\b|\blynch\b|\bshoo?t\b|\bMurder\b|\bFirearm\b
+2129	factoid	How many home runs did Henry "Hank" Aaron hit in his major league career?	\b755\b
+1742	factoid	When did the Mesozoic period end?	\b6[56] million years ago\b
+1606	factoid	What is the boiling point of water?	\b212\s*(.|degrees?)\s*F\b|\b100\s*(.|degrees?)\s*C\b|\b100 o\b|\b101\.325\b
+2152	factoid	When was the Great Wall of China built?	\b2,?000 years ago\b|\b7th century BC\b|\b6.. BC\b|\b2[0-2]. BC\b|\bMing\b
+2102	factoid	What American landmark stands on Liberty Island?	\bStatue of Liberty\b
+2289	factoid	What continent is Togo on?	\bAfrican?\b
+10071	factoid	what is the answer to ultimate question of life, universe and everything?	\b42\b|\bfourty-two\b
+1956	factoid	What country is the largest in square miles?	\bRussia\b
+1983	factoid	When was Lyndon B. Johnson president?	\b1963.*69\b
+1916	factoid	What city did Duke Ellington live in?	\bNew York\b|\bWashington\b|\bNorth Carolina\b
+1859	factoid	What branch of the military has its academy in Annapolis?	\bNav(al|y)\b
+1700	factoid	Where is America's Stonehenge?	\bMystery Hill\b|\bN.H.\b|\bSalem(, New Hampshire)?\b|\bSouth of Manchester\b
+2295	factoid	What 1857 U.S. Supreme Court decision denied that blacks were citizens?	\bDred Scott\b|\bSupreme Court\b
+1713	factoid	What is the name of the phobia for number 13?	\bTriskaidekaphobia\b
+1856	factoid	What city is known as the rubber capital of the world?	\bAkron,?\b
+2121	factoid	What artist recorded the song "At Last" in the 40's or 50's?	\bEtta James\b
+10057	factoid	how long are spaghetti?	\b(25|30|50)\s*c(enti)?m\b|\b(10|12|20)\s*("|in)\b
+1615	factoid	What is Africa's largest country?	\bSudan\b|\bAlgeria\b|\bNigeria\b
+10099	factoid	who are the inventors of the first transistor?	\b((Bardeen|Shockley|Brattain).*){3}\b|\bBardeen\b|\bShockley\b|\bBrattain\b
+10010	factoid	What currency is used in Christiania?	\bL[oø]n\b
+1911	factoid	What is the name of the chart that tells you the symbol for all chemical elements?	\bperiodic (table|chart)\b
+10094	factoid	where was jesus born?,	\bBethlehem\b
+10109	factoid	who wrote ender's game?	\bOrson.*Card\b
+1496	factoid	What country is Berlin in?	\bGermany\b
+1464	factoid	Who is the detective on "Diagnosis Murder"?	\bSteve Sloan\b
+1640	factoid	Who founded Taoism?	\bLao\s*-?\s*T[zs][ue]\b|\bLaozi\b
+1843	factoid	In what month are the most babies born?	\bJuly\b|\bAugust\b|\bSeptember\b
+1669	factoid	How tall is Mount McKinley?	\b20\s?,?\s?(32|40)0\s?-?\s?f(ee|oo)t\b|\b6,194-meter\b|\b20,?237\s*f(oo|ee)?t\b|\b20,?073\s*f(oo|ee)?t\b|\b6,?168\s*m\b|\b6,118\s*m\b|\b6\,194 m\b|\b20\,322 feet\b
+2388	factoid	what Arthur Miller play recounts his marriage to Marilyn Monroe?	\bAfter the Fall\b|\bFinishing the Play\b
+1544	factoid	What is the most populated country in the world?	\bChina\b
+1783	factoid	What country are Volvo automobiles made in?	\bSweden\b
 2193	factoid	How many feet above sea level is Jerusalem?	\b2,?[4567][0-9][0-9]\b
-2297	factoid	What is Britney Spears' middle name?	Jean
-1787	factoid	What is David Lee Roth's birthday?	Oct(.|ober)?\s* 10|1954
-2383	factoid	How did Jerry Garcia Die?	drug abuse|heart attack
-2312	factoid	How many republics made up the Soviet Union?	\b15\b|fifteen|Soviet
-1679	factoid	What is the diameter of the moon?	2,159 miles|3,?474(.2[0-9]*)?\s*m|3\,474 km|2\,159\.2 miles
-2225	factoid	What modern country is home to the ancient city of Babylon?	Iraq
-2190	factoid	What country is Hyundai from?	Republic of Korea|South Korea
-1922	factoid	How fast is an eye blink?	\.(03|[1-4].*)\s*s(econds)?|0.[1-4].*(ms|milliseconds)
-1554	factoid	What is the scientific name for tobacco?	Nicotiana alata|Nicotiana tabacum|Nicotiana rustica
-2050	factoid	What dissolves gold?	cyanide|aqua regia|hydrochloric.*nitrid|HCl.*HNO3
-1665	factoid	When did Marian Anderson sing at the Lincoln Memorial?	1939
-10032	factoid	When is christmas?	Dec.*\b2[45]\b
-1884	factoid	Where is the Sea of Tranquility?	moon
-2216	factoid	How did Dennis Brown die?	pneumo|lung
-2141	factoid	How many justices does the United States Supreme Court have?	nine|\b9\b
-1962	factoid	What country is know as the "Land of the Rising Sun"?	Japan
-1818	factoid	Where did Golda Meir grow up?	Milwaukee|Ukraine|Kiev
-2069	factoid	When was the first Star Wars movie made?	1977|May 25
-1754	factoid	When did the Persian Gulf War occur?	1991
-1677	factoid	How did Micky Mantle die?	cancer|Liver tumour
-2300	factoid	What country did Marco Polo come from?	Ital(y|ian)
-2182	factoid	How far is the Titanic under water?	12,?(000|500|460)\s*f(ee|oo)?t|3,?800\s*m
-1944	factoid	What did George Washington call his house?	Mount Vernon
-10047	factoid	Who is the author of Neuromancer?	Gibson
-10004	factoid	How many colors do you need to color a planar graph?	four|\b4\b
-10103	factoid	who is Barrack Obama?	president.*U.*S|U.*S.*president|President Barack Obama\'s
-1886	factoid	What are Brazil's national colors?	bright yellow and blue|green and yellow
-1846	factoid	What is the oldest sports trophy?	America(\s?')?s Cup
-2059	factoid	How did Chicago get its name?	French.*(onion|garlic)|the wild leeks|the Miami and Illinois Tribes
-2140	factoid	What day did Martin Luther King, Jr. get assassinated?	April 4, 1968|1968\-04\-04
-1672	factoid	What Latin American country is the leading exporter of sugar cane?	Brazil
-2209	factoid	What is the term for arable land left unseeded for one season?	fallow
-2153	factoid	What date did the Lusitania sink?	1915|May
-2281	factoid	What American commodore demanded that Japan trade with the United States?	Perry
-1685	factoid	What is the most populous city in the United States?	New\s?York
-1622	factoid	Who was Woodrow Wilson's First Lady?	(Ellen|Edith)(_Axson_Wilson)?
-2175	factoid	What country did Iraq invade in 1990?	Kuwait
-2318	factoid	What instrument measures radioactivity?	Geiger|dosimeter|End\-window G\-M detectors
-2143	factoid	How did John Dillinger die?	gunned down|shot
-2214	factoid	What country other than Germany has German as its official language?	Austria|Switzerland|Belgium|Luxembourg|Lichtenstein
-1777	factoid	Who did Scott Bakula play in "American Beauty"?	Jim
-10092	factoid	where is Løn used?	Christiania
-1525	factoid	What university did Thomas Jefferson found?	Virginia
-2115	factoid	In what Canadian province are most people of French descent?	Qu[eé]bec
-2049	factoid	What president served 2 nonconsecutive terms?	Grover Cleveland|two non\-consecutive terms
-2025	factoid	What sports stadium has been billed as "the eighth wonder of the world"?	Astrodome
-2202	factoid	How many interceptions did Joe Montana throw in four Superbowls?	never|none|\b0\b|zero
-2110	factoid	what is Speedy Claxton's real name?	Craig
-2021	factoid	What is the world's largest coral reef?	Great Barrier Reef
-1519	factoid	Where was Hans Christian Anderson born?	Denmark|Odense
-1997	factoid	What American revolutionary general turned over West Point to the British?	Arnold
-1563	factoid	Who started the Protestant reformation?	Luther
-2235	factoid	What is the highest mountain in South America?	Aconcagua
-2103	factoid	What confederate general was responsible for the defeat at Gettysburg?	Lee|Pickett
-10054	factoid	how deep is marianas trench?	10[.,]?([89][0-9][0-9])\s*(k|kilo)?m|6,?[89][0-9][0-9]\s*mi|3[56],?[0-9]{3}\s*(f(ee|oo)?t|')
-2305	factoid	When is Mexico's Independence Day?	Sep.*16
-2379	factoid	What is the scientific name for red imported fire ants?	Solenopsis invicta|The red imported fire ant \(
-1838	factoid	What was the name of FDR's dog?	Fala
-2219	factoid	How tall is Al Pacino?	5\s*(f(oo|ee)?t|').*6\s*(in(ch)?(es)?|")|1.7.*cm|1\.7
-1590	factoid	What do grasshoppers eat?	grass\b|plant|roses
-1612	factoid	When was the U.S. invasion of Haiti?	1994|1915
-2323	factoid	What American feminist appeared on a silver dollar?	Susan.*Anthony
-2257	factoid	What is the richest country in the world?	Qatar
-1885	factoid	What language do they officially speak in New Caledonia?	French
-1863	factoid	Who said "I have not begun to fight!"?	John Paul Jones
-2196	factoid	What ocean are the Gilbert Islands in?	Pacific
-1649	factoid	What year did the shuttle Challenger explode?	1986
-1404	factoid	How many chromosomes does a human zygote have?	23 pairs|46
-2030	factoid	How do you say "cat" in the French language?	chat
-1489	factoid	What continent is India on?	Asia
-1498	factoid	What school did Emmitt Smith go to?	Escambia High School
-10088	factoid	what number is considered unlucky in Japanese culture?	four|\b4\b|1
-2283	factoid	What is the traditional dish served at Wimbledon?	strawberr.*cream
-2085	factoid	How close is Mesa to Phoenix?	(1[789]|20) mile|3[0-4]\s*(km|kilometers)|19\.9miles|19\.9 miles|26 min \(19\.9 mi\) via US\-60 W and I\-10 W
-1791	factoid	When did they put Mir down?	1999|2001
-2154	factoid	What is egg white called?	glair|album[ei]n
-10106	factoid	who portrays the twelfth doctor in BBC TV series Doctor Who?	Peter Capaldi|Capaldi
-1499	factoid	Which African country's major export is coffee?	Ethiopia|Tanzania|Uganda
-2246	factoid	What film did Liza Minnelli win a best actress Oscar for?	Cabaret
-10063	factoid	how many months are in a year?	\b12\b|twelve
-1766	factoid	What is Australia's national blossom?	wattle
-2338	factoid	When was the Titanic built?	1909|1911
-1426	factoid	Who is the governor of Tennessee in 2002?	Sundquist
-2325	factoid	When was the first Superbowl?	1967
-1704	factoid	What is the normal pulse rate?	70 beats per minute|60.*100\s*(bpm|beats per minute)
-1629	factoid	Where is Mae West buried?	Cypress Hills Abbey|New York
-2355	factoid	What 20th century American president died at Warm Springs, Georgia?	Roosevelt|FDR
-1706	factoid	What is the beginning date for the Hershey foods company?	1903|1894
-1732	factoid	What are the opening words of the Declaration of Independence?	We hold these truths|When in the Course of human events
-1431	factoid	Who starred in "The Poseidon Adventure"?	Gene Hackman|McDowall|Borgnine
-1623	factoid	What is the active ingredient in Tylenol?	acetaminophen
-1553	factoid	Who makes Magic Chef refrigerators?	Maytag|CNA|MC Appliance
-1751	factoid	Where is Mesa Verde National park?	Colo(\.?|rado)|Cortez
-1639	factoid	What is the profession of John Cusack's character in the 1999 film "Pushing Tin"?	air(\s|-)traffic(\s|-)controller
-2357	factoid	What city's biggest shopping district is called the Ginza District?	Tokyo('s)?
-2091	factoid	What is Eminem's real name?	Marshall.*?Mathers
-1413	factoid	What river is called "China's Sorrow"?	Yellow|Yangzi|Yangtze
-2351	factoid	How long before bankruptcy is removed from a credit report?	(10|ten|\b7|seven) years
-1936	factoid	How many stories are in the Sears Tower?	(100|110|10[6-9])
-1771	factoid	When was D-Day?	1944|June? 6
-1675	factoid	What group sang the song "Happy Together"?	Turtles
-2284	factoid	What Chinese Dynasty was during 1412-1431?	Ming
-1845	factoid	What province is Calgary located in?	Alberta
-1628	factoid	How much area does the Everglades cover?	2,000 square miles|734\s*sq(uare)?\s*m(iles)?|1,?900\s*(square\s*)?km
-2199	factoid	What band was Jimmy Page in before Led Zeppelin?	Yardbirds
-1961	factoid	What position did Satchel Paige play in professional baseball?	pitcher
-10001	factoid	How many Platonic solids do we have?	\b5\b|five
-2212	factoid	What country artist is nicknamed Tater?	Little Jimmy Dickens|Williams
-2123	factoid	When was John Lennon born?	1940|October
-1966	factoid	What capital city do you see from the top of Bunker Hill?	Boston
-2156	factoid	How fast does Randy Johnson throw?	(95|98|100(.1)?).*?(mph|miles per hour)|160\s*(km|kilometers).*h|102 MPH|randy Johnson|the fastest pitch|the theoretical maximum speed that a pitcher can throw
-2270	factoid	What is capital of Maryland?	Annapolis|the State capital of Maryland
-1803	factoid	When did Willis Haviland Carrier make the air conditioner?	1902
-2285	factoid	How much does the capitol dome weigh?	14.1 million pounds
-1809	factoid	When was the Buckingham Palace built in London, England?	1703
-2053	factoid	What duo lost their Grammy for best new artist when it was discovered that they lip-synched their songs?	Milli Vanilli
-1767	factoid	When was the first Ford Mustang made?	1964
-2306	factoid	How big is the Great Pyramid?	146.5\s*m|481\s*f(oo|ee)?t|138.8\s*m|455\s*f(oo|ee)?t|230.4\s*m|756\s*f(oo|ee)?t
-1520	factoid	What is the capital of Kentucky?	Frankfort
-10016	factoid	What is the capital city of Ukraine?	Kiev
-1466	factoid	How tall is Allen Iverson?	6\s?-?\s?f(ee|oo)?t|six\s?-?feet|1.83\s*m|183\s*cm|5ft 11in
-10011	factoid	What currency is used in Ukraine?	UAH|hryvnia
-1734	factoid	How do you say "pig" in Spanish?	Cerdo
-2301	factoid	What composer wrote "Die Gotterdammerung"?	Wagner
-1492	factoid	How old was Nolan Ryan when he retired?	4(4|6)
-10045	factoid	Who invented bitcoin?	Nakamoto
-10006	factoid	How old did Jesus die?	\b33\b|thirty-three
-1504	factoid	Where is the Salton Sea?	Calif(\s?\.|ornia)
-1851	factoid	Which country colonized Hong Kong?	Britain
-1646	factoid	When was the first atomic bomb dropped?	Aug.*1945|1945
-1973	factoid	What player on a basketball team usually plays the post or pivot position?	center
-1483	factoid	Where is the highest point on earth?	Everest
-1899	factoid	What book did Rachel Carson write in 1962?	Silent Spring
-2342	factoid	When was the first televised World Series?	1947
-1904	factoid	How high is the pitcher's mound?	(ten|10)\s*in(ch(es)?)?|25.4\s*(cm|centimeters?)
-2040	factoid	What are baby frogs called?	tadpole
-10069	factoid	what can mandrills at the Colchester Zoo do?	cover.*eye
-2331	factoid	What actress has received the most Oscar nominations?	Hepburn|Streep
-1491	factoid	What was the name of Sherlock Holmes' brother?	Mycroft
-10053	factoid	chemical symbol of ethylene ?	C.*2.*H.*4
-1658	factoid	What year was Robert Frost born?	187(4|5)
-1515	factoid	What was Dr. Seuss' real name?	Theodore? (Seuss )?Geisel|Geisel
-1564	factoid	When did Led Zeppelin appear on BBC?	1969|1997
-1719	factoid	What is the distance from Jupiter to the sun?	(777|800) million kilometers|778,?500,?000\s*km|483,?800,?000\s*miles|483\.8 million miles
-2268	factoid	what instrument does the concertmaster of an orchestra usually play?	violin
-2240	factoid	What does the bugler play at the end of the day on a US military base?	Taps
-2386	factoid	How did Harry Houdini die?	ruptured appendix|peritonitis|appendicitis
-1812	factoid	What was the name of the stage play that A. Lincoln died at?	Our American Cousin
-1506	factoid	What's the name of King Arthur's sword?	Excalibur
-2236	factoid	What country's flag flies over the Canary Islands?	Spa(in|nish)
-1470	factoid	When did president Herbert Hoover die?	1964
-1931	factoid	When was Prince Charles born?	1948
-2018	factoid	How many Mars days are there in a Martian year?	66[89]
-10025	factoid	What is the highest mountain in the Czech Republic?	Sne[zž]ka|Sn\ě\žka
-2007	factoid	How many years are there in a French president's term?	seven|\b7\b
-1524	factoid	What is the name of the ballpark that the Milwaukee Brewers play at?	County Stadium|Miller Park
-1453	factoid	Where was the first J.C. Penney store opened?	Kemmerer\s?, Wyo\.?
-1585	factoid	What is the chief religion for Peru?	Catholic
-2367	factoid	How tall is the Washington Monument?	555\s*('|f(ee|oo)?t)|169\s*m
-1526	factoid	What is the city of brotherly love?	Philadelphia
-2269	factoid	How long is a quarter in an NBA game?	12.m.*
-1625	factoid	What is the deepest lake in the world?	Baikal
-1580	factoid	What name is given to the science of map-making?	Cartography
-10018	factoid	What is the color of blood?	red
-1423	factoid	What is a peninsula in the Philippines?	Bataan|Bicol|Zamboanga
-1892	factoid	Where does cinnamon come from?	Sri Lanka
-1417	factoid	Who was the first person to run the mile in less than four minutes?	Roger Bannister
-10086	factoid	what is the sixteenth episode of the sixth season of the science fiction television series The X-Files?	Alpha
-2009	factoid	What animal has human-like fingerprints?	koala
-2249	factoid	When was the Panama Canal returned to Panama?	1999|1904
-1909	factoid	What business was the source of John D. Rockefeller's fortune?	oil
-1458	factoid	What was the name of the high school in "Grease"?	Rydell
-10108	factoid	who received the Nobel Prize for Physiology and Medicine in the year 2013?	((Rothman|Schekman|S[uü]dhof).*){3}
-10104	factoid	who is the author of Sherlock Holmes?	Doyle
-10000	factoid	How high is Mt. Everest?	29,?029\s*('|f(ee|oo)?t)|8,?848\s*m
-1986	factoid	What city is Ole Mississippi University in?	Oxford
-1603	factoid	When did Robert E. Lee surrender in the Civil War?	1865|April 9
-10079	factoid	what is the most lethal poison?	botulin
-1768	factoid	What TV series did Pierce Brosnan play in?	Remington Steele(.*)?|Running Wilde|Hammer House of Horror
-1993	factoid	How many official languages does Switzerland have?	four|\b4\b
-1591	factoid	What percentage of the population is left handed?	(ten|10)\s*(percent|%)
-1879	factoid	By what nickname was musician Ernesto Antonio Puente, Jr. best known?	El Rey|Tito
-1975	factoid	How did Cleopatra die?	asp bite|suicide|a painful and unpleasant experience
-1796	factoid	What year did General Montgomery lead the Allies to a victory over the Axis troops in North Africa?	1942
-1847	factoid	What is Tina Turners real name?	Ann(a|ie) Mae Bullock
+2297	factoid	What is Britney Spears' middle name?	\bJean\b
+1787	factoid	What is David Lee Roth's birthday?	\bOct(.|ober)?\s* 10\b|\b1954\b
+2383	factoid	How did Jerry Garcia Die?	\bdrug abuse\b|\bheart attack\b
+2312	factoid	How many republics made up the Soviet Union?	\b15\b|\bfifteen\b|\bSoviet\b
+1679	factoid	What is the diameter of the moon?	\b2,159 miles\b|\b3,?474(.2[0-9]*)?\s*m\b|\b3\,474 km\b|\b2\,159\.2 miles\b
+2225	factoid	What modern country is home to the ancient city of Babylon?	\bIraq\b
+2190	factoid	What country is Hyundai from?	\bRepublic of Korea\b|\bSouth Korea\b
+1922	factoid	How fast is an eye blink?	\b\.(03|[1-4].*)\s*s(econds)?\b|\b0.[1-4].*(ms|milliseconds)\b
+1554	factoid	What is the scientific name for tobacco?	\bNicotiana alata\b|\bNicotiana tabacum\b|\bNicotiana rustica\b
+2050	factoid	What dissolves gold?	\bcyanide\b|\baqua regia\b|\bhydrochloric.*nitrid\b|\bHCl.*HNO3\b
+1665	factoid	When did Marian Anderson sing at the Lincoln Memorial?	\b1939\b
+10032	factoid	When is christmas?	\bDec.*\b2[45]\b
+1884	factoid	Where is the Sea of Tranquility?	\bmoon\b
+2216	factoid	How did Dennis Brown die?	\bpneumo\b|\blung\b
+2141	factoid	How many justices does the United States Supreme Court have?	\bnine\b|\b9\b
+1962	factoid	What country is know as the "Land of the Rising Sun"?	\bJapan\b
+1818	factoid	Where did Golda Meir grow up?	\bMilwaukee\b|\bUkraine\b|\bKiev\b
+2069	factoid	When was the first Star Wars movie made?	\b1977\b|\bMay 25\b
+1754	factoid	When did the Persian Gulf War occur?	\b1991\b
+1677	factoid	How did Micky Mantle die?	\bcancer\b|\bLiver tumour\b
+2300	factoid	What country did Marco Polo come from?	\bItal(y|ian)\b
+2182	factoid	How far is the Titanic under water?	\b12,?(000|500|460)\s*f(ee|oo)?t\b|\b3,?800\s*m\b
+1944	factoid	What did George Washington call his house?	\bMount Vernon\b
+10047	factoid	Who is the author of Neuromancer?	\bGibson\b
+10004	factoid	How many colors do you need to color a planar graph?	\bfour\b|\b4\b
+10103	factoid	who is Barrack Obama?	\bpresident.*U.*S\b|\bU.*S.*president\b|\bPresident Barack Obama\'s\b
+1886	factoid	What are Brazil's national colors?	\bbright yellow and blue\b|\bgreen and yellow\b
+1846	factoid	What is the oldest sports trophy?	\bAmerica(\s?')?s Cup\b
+2059	factoid	How did Chicago get its name?	\bFrench.*(onion|garlic)\b|\bthe wild leeks\b|\bthe Miami and Illinois Tribes\b
+2140	factoid	What day did Martin Luther King, Jr. get assassinated?	\bApril 4, 1968\b|\b1968\-04\-04\b
+1672	factoid	What Latin American country is the leading exporter of sugar cane?	\bBrazil\b
+2209	factoid	What is the term for arable land left unseeded for one season?	\bfallow\b
+2153	factoid	What date did the Lusitania sink?	\b1915\b|\bMay\b
+2281	factoid	What American commodore demanded that Japan trade with the United States?	\bPerry\b
+1685	factoid	What is the most populous city in the United States?	\bNew\s?York\b
+1622	factoid	Who was Woodrow Wilson's First Lady?	\b(Ellen|Edith)(_Axson_Wilson)?\b
+2175	factoid	What country did Iraq invade in 1990?	\bKuwait\b
+2318	factoid	What instrument measures radioactivity?	\bGeiger\b|\bdosimeter\b|\bEnd\-window G\-M detectors\b
+2143	factoid	How did John Dillinger die?	\bgunned down\b|\bshot\b
+2214	factoid	What country other than Germany has German as its official language?	\bAustria\b|\bSwitzerland\b|\bBelgium\b|\bLuxembourg\b|\bLichtenstein\b
+1777	factoid	Who did Scott Bakula play in "American Beauty"?	\bJim\b
+10092	factoid	where is Løn used?	\bChristiania\b
+1525	factoid	What university did Thomas Jefferson found?	\bVirginia\b
+2115	factoid	In what Canadian province are most people of French descent?	\bQu[eé]bec\b
+2049	factoid	What president served 2 nonconsecutive terms?	\bGrover Cleveland\b|\btwo non\-consecutive terms\b
+2025	factoid	What sports stadium has been billed as "the eighth wonder of the world"?	\bAstrodome\b
+2202	factoid	How many interceptions did Joe Montana throw in four Superbowls?	\bnever\b|\bnone\b|\b0\b|\bzero\b
+2110	factoid	what is Speedy Claxton's real name?	\bCraig\b
+2021	factoid	What is the world's largest coral reef?	\bGreat Barrier Reef\b
+1519	factoid	Where was Hans Christian Anderson born?	\bDenmark\b|\bOdense\b
+1997	factoid	What American revolutionary general turned over West Point to the British?	\bArnold\b
+1563	factoid	Who started the Protestant reformation?	\bLuther\b
+2235	factoid	What is the highest mountain in South America?	\bAconcagua\b
+2103	factoid	What confederate general was responsible for the defeat at Gettysburg?	\bLee\b|\bPickett\b
+10054	factoid	how deep is marianas trench?	\b10[.,]?([89][0-9][0-9])\s*(k|kilo)?m\b|\b6,?[89][0-9][0-9]\s*mi\b|\b3[56],?[0-9]{3}\s*(f(ee|oo)?t\b|\b')\b
+2305	factoid	When is Mexico's Independence Day?	\bSep.*16\b
+2379	factoid	What is the scientific name for red imported fire ants?	\bSolenopsis invicta\b|\bThe red imported fire ant \(\b
+1838	factoid	What was the name of FDR's dog?	\bFala\b
+2219	factoid	How tall is Al Pacino?	\b5\s*(f(oo|ee)?t\b|\b').*6\s*(in(ch)?(es)?\b|\b")\b|\b1.7.*cm\b|\b1\.7\b
+1590	factoid	What do grasshoppers eat?	\bgrass\b|\bplant\b|\broses\b
+1612	factoid	When was the U.S. invasion of Haiti?	\b1994\b|\b1915\b
+2323	factoid	What American feminist appeared on a silver dollar?	\bSusan.*Anthony\b
+2257	factoid	What is the richest country in the world?	\bQatar\b
+1885	factoid	What language do they officially speak in New Caledonia?	\bFrench\b
+1863	factoid	Who said "I have not begun to fight!"?	\bJohn Paul Jones\b
+2196	factoid	What ocean are the Gilbert Islands in?	\bPacific\b
+1649	factoid	What year did the shuttle Challenger explode?	\b1986\b
+1404	factoid	How many chromosomes does a human zygote have?	\b23 pairs\b|\b46\b
+2030	factoid	How do you say "cat" in the French language?	\bchat\b
+1489	factoid	What continent is India on?	\bAsia\b
+1498	factoid	What school did Emmitt Smith go to?	\bEscambia High School\b
+10088	factoid	what number is considered unlucky in Japanese culture?	\bfour\b|\b4\b|\b1\b
+2283	factoid	What is the traditional dish served at Wimbledon?	\bstrawberr.*cream\b
+2085	factoid	How close is Mesa to Phoenix?	\b(1[789]|20) mile\b|\b3[0-4]\s*(km|kilometers)\b|\b19\.9miles\b|\b19\.9 miles\b|\b26 min \(19\.9 mi\) via US\-60 W and I\-10 W\b
+1791	factoid	When did they put Mir down?	\b1999\b|\b2001\b
+2154	factoid	What is egg white called?	\bglair\b|\balbum[ei]n\b
+10106	factoid	who portrays the twelfth doctor in BBC TV series Doctor Who?	\bPeter Capaldi\b|\bCapaldi\b
+1499	factoid	Which African country's major export is coffee?	\bEthiopia\b|\bTanzania\b|\bUganda\b
+2246	factoid	What film did Liza Minnelli win a best actress Oscar for?	\bCabaret\b
+10063	factoid	how many months are in a year?	\b12\b|\btwelve\b
+1766	factoid	What is Australia's national blossom?	\bwattle\b
+2338	factoid	When was the Titanic built?	\b1909\b|\b1911\b
+1426	factoid	Who is the governor of Tennessee in 2002?	\bSundquist\b
+2325	factoid	When was the first Superbowl?	\b1967\b
+1704	factoid	What is the normal pulse rate?	\b70 beats per minute\b|\b60.*100\s*(bpm|beats per minute)\b
+1629	factoid	Where is Mae West buried?	\bCypress Hills Abbey\b|\bNew York\b
+2355	factoid	What 20th century American president died at Warm Springs, Georgia?	\bRoosevelt\b|\bFDR\b
+1706	factoid	What is the beginning date for the Hershey foods company?	\b1903\b|\b1894\b
+1732	factoid	What are the opening words of the Declaration of Independence?	\bWe hold these truths\b|\bWhen in the Course of human events\b
+1431	factoid	Who starred in "The Poseidon Adventure"?	\bGene Hackman\b|\bMcDowall\b|\bBorgnine\b
+1623	factoid	What is the active ingredient in Tylenol?	\bacetaminophen\b
+1553	factoid	Who makes Magic Chef refrigerators?	\bMaytag\b|\bCNA\b|\bMC Appliance\b
+1751	factoid	Where is Mesa Verde National park?	\bColo(\.?|rado)\b|\bCortez\b
+1639	factoid	What is the profession of John Cusack's character in the 1999 film "Pushing Tin"?	\bair(\s|-)traffic(\s|-)controller\b
+2357	factoid	What city's biggest shopping district is called the Ginza District?	\bTokyo('s)?\b
+2091	factoid	What is Eminem's real name?	\bMarshall.*?Mathers\b
+1413	factoid	What river is called "China's Sorrow"?	\bYellow\b|\bYangzi\b|\bYangtze\b
+2351	factoid	How long before bankruptcy is removed from a credit report?	\b(10|ten|\b7|seven) years\b
+1936	factoid	How many stories are in the Sears Tower?	\b(100|110|10[6-9])\b
+1771	factoid	When was D-Day?	\b1944\b|\bJune? 6\b
+1675	factoid	What group sang the song "Happy Together"?	\bTurtles\b
+2284	factoid	What Chinese Dynasty was during 1412-1431?	\bMing\b
+1845	factoid	What province is Calgary located in?	\bAlberta\b
+1628	factoid	How much area does the Everglades cover?	\b2,000 square miles\b|\b734\s*sq(uare)?\s*m(iles)?\b|\b1,?900\s*(square\s*)?km\b
+2199	factoid	What band was Jimmy Page in before Led Zeppelin?	\bYardbirds\b
+1961	factoid	What position did Satchel Paige play in professional baseball?	\bpitcher\b
+10001	factoid	How many Platonic solids do we have?	\b5\b|\bfive\b
+2212	factoid	What country artist is nicknamed Tater?	\bLittle Jimmy Dickens\b|\bWilliams\b
+2123	factoid	When was John Lennon born?	\b1940\b|\bOctober\b
+1966	factoid	What capital city do you see from the top of Bunker Hill?	\bBoston\b
+2156	factoid	How fast does Randy Johnson throw?	\b(95|98|100(.1)?).*?(mph|miles per hour)\b|\b160\s*(km|kilometers).*h\b|\b102 MPH\b|\brandy Johnson\b|\bthe fastest pitch\b|\bthe theoretical maximum speed that a pitcher can throw\b
+2270	factoid	What is capital of Maryland?	\bAnnapolis\b|\bthe State capital of Maryland\b
+1803	factoid	When did Willis Haviland Carrier make the air conditioner?	\b1902\b
+2285	factoid	How much does the capitol dome weigh?	\b14.1 million pounds\b
+1809	factoid	When was the Buckingham Palace built in London, England?	\b1703\b
+2053	factoid	What duo lost their Grammy for best new artist when it was discovered that they lip-synched their songs?	\bMilli Vanilli\b
+1767	factoid	When was the first Ford Mustang made?	\b1964\b
+2306	factoid	How big is the Great Pyramid?	\b146.5\s*m\b|\b481\s*f(oo|ee)?t\b|\b138.8\s*m\b|\b455\s*f(oo|ee)?t\b|\b230.4\s*m\b|\b756\s*f(oo|ee)?t\b
+1520	factoid	What is the capital of Kentucky?	\bFrankfort\b
+10016	factoid	What is the capital city of Ukraine?	\bKiev\b
+1466	factoid	How tall is Allen Iverson?	\b6\s?-?\s?f(ee|oo)?t\b|\bsix\s?-?feet\b|\b1.83\s*m\b|\b183\s*cm\b|\b5ft 11in\b
+10011	factoid	What currency is used in Ukraine?	\bUAH\b|\bhryvnia\b
+1734	factoid	How do you say "pig" in Spanish?	\bCerdo\b
+2301	factoid	What composer wrote "Die Gotterdammerung"?	\bWagner\b
+1492	factoid	How old was Nolan Ryan when he retired?	\b4(4|6)\b
+10045	factoid	Who invented bitcoin?	\bNakamoto\b
+10006	factoid	How old did Jesus die?	\b33\b|\bthirty-three\b
+1504	factoid	Where is the Salton Sea?	\bCalif(\s?\.|ornia)\b
+1851	factoid	Which country colonized Hong Kong?	\bBritain\b
+1646	factoid	When was the first atomic bomb dropped?	\bAug.*1945\b|\b1945\b
+1973	factoid	What player on a basketball team usually plays the post or pivot position?	\bcenter\b
+1483	factoid	Where is the highest point on earth?	\bEverest\b
+1899	factoid	What book did Rachel Carson write in 1962?	\bSilent Spring\b
+2342	factoid	When was the first televised World Series?	\b1947\b
+1904	factoid	How high is the pitcher's mound?	\b(ten|10)\s*in(ch(es)?)?\b|\b25.4\s*(cm|centimeters?)\b
+2040	factoid	What are baby frogs called?	\btadpole\b
+10069	factoid	what can mandrills at the Colchester Zoo do?	\bcover.*eye\b
+2331	factoid	What actress has received the most Oscar nominations?	\bHepburn\b|\bStreep\b
+1491	factoid	What was the name of Sherlock Holmes' brother?	\bMycroft\b
+10053	factoid	chemical symbol of ethylene ?	\bC.*2.*H.*4\b
+1658	factoid	What year was Robert Frost born?	\b187(4|5)\b
+1515	factoid	What was Dr. Seuss' real name?	\bTheodore? (Seuss )?Geisel\b|\bGeisel\b
+1564	factoid	When did Led Zeppelin appear on BBC?	\b1969\b|\b1997\b
+1719	factoid	What is the distance from Jupiter to the sun?	\b(777|800) million kilometers\b|\b778,?500,?000\s*km\b|\b483,?800,?000\s*miles\b|\b483\.8 million miles\b
+2268	factoid	what instrument does the concertmaster of an orchestra usually play?	\bviolin\b
+2240	factoid	What does the bugler play at the end of the day on a US military base?	\bTaps\b
+2386	factoid	How did Harry Houdini die?	\bruptured appendix\b|\bperitonitis\b|\bappendicitis\b
+1812	factoid	What was the name of the stage play that A. Lincoln died at?	\bOur American Cousin\b
+1506	factoid	What's the name of King Arthur's sword?	\bExcalibur\b
+2236	factoid	What country's flag flies over the Canary Islands?	\bSpa(in|nish)\b
+1470	factoid	When did president Herbert Hoover die?	\b1964\b
+1931	factoid	When was Prince Charles born?	\b1948\b
+2018	factoid	How many Mars days are there in a Martian year?	\b66[89]\b
+10025	factoid	What is the highest mountain in the Czech Republic?	\bSne[zž]ka\b|\bSn\ě\žka\b
+2007	factoid	How many years are there in a French president's term?	\bseven\b|\b7\b
+1524	factoid	What is the name of the ballpark that the Milwaukee Brewers play at?	\bCounty Stadium\b|\bMiller Park\b
+1453	factoid	Where was the first J.C. Penney store opened?	\bKemmerer\s?, Wyo\.?\b
+1585	factoid	What is the chief religion for Peru?	\bCatholic\b
+2367	factoid	How tall is the Washington Monument?	\b555\s*('|f(ee|oo)?t)\b|\b169\s*m\b
+1526	factoid	What is the city of brotherly love?	\bPhiladelphia\b
+2269	factoid	How long is a quarter in an NBA game?	\b12.m.*\b
+1625	factoid	What is the deepest lake in the world?	\bBaikal\b
+1580	factoid	What name is given to the science of map-making?	\bCartography\b
+10018	factoid	What is the color of blood?	\bred\b
+1423	factoid	What is a peninsula in the Philippines?	\bBataan\b|\bBicol\b|\bZamboanga\b
+1892	factoid	Where does cinnamon come from?	\bSri Lanka\b
+1417	factoid	Who was the first person to run the mile in less than four minutes?	\bRoger Bannister\b
+10086	factoid	what is the sixteenth episode of the sixth season of the science fiction television series The X-Files?	\bAlpha\b
+2009	factoid	What animal has human-like fingerprints?	\bkoala\b
+2249	factoid	When was the Panama Canal returned to Panama?	\b1999\b|\b1904\b
+1909	factoid	What business was the source of John D. Rockefeller's fortune?	\boil\b
+1458	factoid	What was the name of the high school in "Grease"?	\bRydell\b
+10108	factoid	who received the Nobel Prize for Physiology and Medicine in the year 2013?	\b((Rothman|Schekman|S[uü]dhof).*){3}\b
+10104	factoid	who is the author of Sherlock Holmes?	\bDoyle\b
+10000	factoid	How high is Mt. Everest?	\b29,?029\s*('|f(ee|oo)?t)\b|\b8,?848\s*m\b
+1986	factoid	What city is Ole Mississippi University in?	\bOxford\b
+1603	factoid	When did Robert E. Lee surrender in the Civil War?	\b1865\b|\bApril 9\b
+10079	factoid	what is the most lethal poison?	\bbotulin\b
+1768	factoid	What TV series did Pierce Brosnan play in?	\bRemington Steele(.*)?\b|\bRunning Wilde\b|\bHammer House of Horror\b
+1993	factoid	How many official languages does Switzerland have?	\bfour\b|\b4\b
+1591	factoid	What percentage of the population is left handed?	\b(ten|10)\s*(percent|%)\b
+1879	factoid	By what nickname was musician Ernesto Antonio Puente, Jr. best known?	\bEl Rey\b|\bTito\b
+1975	factoid	How did Cleopatra die?	\basp bite\b|\bsuicide\b|\ba painful and unpleasant experience\b
+1796	factoid	What year did General Montgomery lead the Allies to a victory over the Axis troops in North Africa?	\b1942\b
+1847	factoid	What is Tina Turners real name?	\bAnn(a|ie) Mae Bullock\b
 2293	factoid	How many times a day do observant Muslims pray?	\b(five|5)\b
-1596	factoid	What year did Mussolini seize power in Italy?	1922
-1995	factoid	What department is responsible for regulating casino gambling in Mississippi?	Mississippi Gaming Commission
-1507	factoid	What is the national anthem in England?	God Save the Queen|Jerusalem|Land of Hope and Glory
-1778	factoid	When did Walt Disney die?	1966
-1731	factoid	How often does the United States government conduct an official population census?	(10|ten) years
-1712	factoid	Who invented the fishing reel?	Chinese|R.\s?D. Hull|Ustonson
-1502	factoid	What year was President Kennedy killed?	1963
-1395	factoid	Who was Tom Cruise married to last?	Katie Holmes
-1671	factoid	Where is Big Ben?	London|Westminster
-2187	factoid	What is the big prize called in Canadian football?	Grey Cup
-1557	factoid	What was the first satellite in space?	Sputnik
-10024	factoid	What is the first derivative of x^2?	2\s*.?\s*x
-2380	factoid	What is the name of the official residence of the President of France?	[EÉ]lys[ée]e palace
-10087	factoid	what language is used by nltk?	Python
-1415	factoid	Where does the vice president live when in office?	U.S\s?. Naval Observatory|United States
-2004	factoid	What do the opposite sides of a die add up to?	seven|\b7\b
-1634	factoid	What is the area of Venezuela?	340,569 square miles|353,?841\s*sq(uare)?\s*m(iles)?|916,?445\s*(square\s*)?km|916445\.0|916\,445 square kilometers and a land area of 882\,050 square kilometers\, \.\.\. Fauna\; Flora \.\.\.
-10098	factoid	which number corresponds to * in ASCII?	\b42\b|0x2a
-2204	factoid	What actor has a tattoo on his right wrist reading "Scotland forever"?	Connery
-2093	factoid	Which city is home to Superman?	Metropolis
-1408	factoid	Which political party is Lionel Jospin a member of?	Socialist
-1800	factoid	Which president was sworn into office on an airplane?	Lyndon Johnson|Lyndon B\. Johnson
-1918	factoid	How did Jimi Hendrix die?	chok(e|ing)|Barbiturate overdose
-1941	factoid	What membrane controls the amount of light entering the eye?	iris
-2078	factoid	What is Corian made of?	acrylic.*alumina|alumina.*acrylic
-10077	factoid	what is the moon of jupiter?	((Io|Europa|Ganymede|Callisto).*){4}|Io|Europe|Ganymede|Callisto|the four Galilean moons
-1465	factoid	What company makes Bentley cars?	Rolls\s?-?\s?Royce|VW|Volkswagen|Bentley Motors
-10096	factoid	which is the central region of the anterior part of the hand?	palm
-1494	factoid	Who wrote "East is east, west is west and never the twain shall meet"?	Kipling
-1929	factoid	What band did the music for the 1970's film "Saturday Night Fever"?	Bee Gees
-2109	factoid	When was the U.N. created?	1945
-2359	factoid	What country's soldiers hid in the Trojan horse?	Greek
-1574	factoid	When did "The Simpsons" first appear on television?	198(7|9)
-1398	factoid	What year was Alaska purchased?	1867
-1601	factoid	When did Einstein die?	1955
-10105	factoid	who is the author of the TV series BBC Sherlock?	((Gatiss|Moffat).*){2}| Thompson|Mark Gatiss|Steven Moffat| Moffat Stephen 
-1930	factoid	What band was Jerry Garcia with?	Grateful Dead|Jerry Garcia Acoustic Band|Wildwood Boys
-1428	factoid	Who won the Nobel Peace Prize in 1992?	Mench[uú]|Mench
-1900	factoid	What country is Aswan High Dam located in?	Egypt|the Sudan
-1497	factoid	What was the original name before "The Star Spangled Banner"?	Defen[cs]e of Fort M'Henry
-10039	factoid	Where was Declaration of Independence signed?	Philadelphia
-1562	factoid	Where did the U.S. Civil War begin?	Fort Sumter
-1741	factoid	What author wrote under the pen name "Boz"?	Dickens
-1947	factoid	What country did Catherine the Great rule?	Russian?
-1412	factoid	Who was the governor of Colorado in 2003?	Owens
-1853	factoid	Where was the Andersonville Prison?	G(eorgi)?a\.?
-10061	factoid	how many generations are in Gospel of Matthew's version of the Genealogy of Jesus?	\b4[01]\b|4
-1804	factoid	Which river runs through Dublin?	Liffey|Dodder|Tolka
-2058	factoid	What is the motto of the "New York Times"?	all the news that's fit to print
-2264	factoid	How old was Elvis when he died?	42
-1827	factoid	Where was the battle of Alamo fought?	San Antonio|Texas
+1596	factoid	What year did Mussolini seize power in Italy?	\b1922\b
+1995	factoid	What department is responsible for regulating casino gambling in Mississippi?	\bMississippi Gaming Commission\b
+1507	factoid	What is the national anthem in England?	\bGod Save the Queen\b|\bJerusalem\b|\bLand of Hope and Glory\b
+1778	factoid	When did Walt Disney die?	\b1966\b
+1731	factoid	How often does the United States government conduct an official population census?	\b(10|ten) years\b
+1712	factoid	Who invented the fishing reel?	\bChinese\b|\bR.\s?D. Hull\b|\bUstonson\b
+1502	factoid	What year was President Kennedy killed?	\b1963\b
+1395	factoid	Who was Tom Cruise married to last?	\bKatie Holmes\b
+1671	factoid	Where is Big Ben?	\bLondon\b|\bWestminster\b
+2187	factoid	What is the big prize called in Canadian football?	\bGrey Cup\b
+1557	factoid	What was the first satellite in space?	\bSputnik\b
+10024	factoid	What is the first derivative of x^2?	\b2\s*.?\s*x\b
+2380	factoid	What is the name of the official residence of the President of France?	\b[EÉ]lys[ée]e palace\b
+10087	factoid	what language is used by nltk?	\bPython\b
+1415	factoid	Where does the vice president live when in office?	\bU.S\s?. Naval Observatory\b|\bUnited States\b
+2004	factoid	What do the opposite sides of a die add up to?	\bseven\b|\b7\b
+1634	factoid	What is the area of Venezuela?	\b340,569 square miles\b|\b353,?841\s*sq(uare)?\s*m(iles)?\b|\b916,?445\s*(square\s*)?km\b|\b916445\.0\b|\b916\,445 square kilometers and a land area of 882\,050 square kilometers\, \.\.\. Fauna\; Flora \.\.\.\b
+10098	factoid	which number corresponds to * in ASCII?	\b42\b|\b0x2a\b
+2204	factoid	What actor has a tattoo on his right wrist reading "Scotland forever"?	\bConnery\b
+2093	factoid	Which city is home to Superman?	\bMetropolis\b
+1408	factoid	Which political party is Lionel Jospin a member of?	\bSocialist\b
+1800	factoid	Which president was sworn into office on an airplane?	\bLyndon Johnson\b|\bLyndon B\. Johnson\b
+1918	factoid	How did Jimi Hendrix die?	\bchok(e|ing)\b|\bBarbiturate overdose\b
+1941	factoid	What membrane controls the amount of light entering the eye?	\biris\b
+2078	factoid	What is Corian made of?	\bacrylic.*alumina\b|\balumina.*acrylic\b
+10077	factoid	what is the moon of jupiter?	\b((Io|Europa|Ganymede|Callisto).*){4}\b|\bIo\b|\bEurope\b|\bGanymede\b|\bCallisto\b|\bthe four Galilean moons\b
+1465	factoid	What company makes Bentley cars?	\bRolls\s?-?\s?Royce\b|\bVW\b|\bVolkswagen\b|\bBentley Motors\b
+10096	factoid	which is the central region of the anterior part of the hand?	\bpalm\b
+1494	factoid	Who wrote "East is east, west is west and never the twain shall meet"?	\bKipling\b
+1929	factoid	What band did the music for the 1970's film "Saturday Night Fever"?	\bBee Gees\b
+2109	factoid	When was the U.N. created?	\b1945\b
+2359	factoid	What country's soldiers hid in the Trojan horse?	\bGreek\b
+1574	factoid	When did "The Simpsons" first appear on television?	\b198(7|9)\b
+1398	factoid	What year was Alaska purchased?	\b1867\b
+1601	factoid	When did Einstein die?	\b1955\b
+10105	factoid	who is the author of the TV series BBC Sherlock?	\b((Gatiss|Moffat).*){2}\b|\b Thompson\b|\bMark Gatiss\b|\bSteven Moffat\b|\b Moffat Stephen\b
+1930	factoid	What band was Jerry Garcia with?	\bGrateful Dead\b|\bJerry Garcia Acoustic Band\b|\bWildwood Boys\b
+1428	factoid	Who won the Nobel Peace Prize in 1992?	\bMench[uú]\b|\bMench\b
+1900	factoid	What country is Aswan High Dam located in?	\bEgypt\b|\bthe Sudan\b
+1497	factoid	What was the original name before "The Star Spangled Banner"?	\bDefen[cs]e of Fort M'Henry\b
+10039	factoid	Where was Declaration of Independence signed?	\bPhiladelphia\b
+1562	factoid	Where did the U.S. Civil War begin?	\bFort Sumter\b
+1741	factoid	What author wrote under the pen name "Boz"?	\bDickens\b
+1947	factoid	What country did Catherine the Great rule?	\bRussian?\b
+1412	factoid	Who was the governor of Colorado in 2003?	\bOwens\b
+1853	factoid	Where was the Andersonville Prison?	\bG(eorgi)?a\.?\b
+10061	factoid	how many generations are in Gospel of Matthew's version of the Genealogy of Jesus?	\b4[01]\b|\b4\b
+1804	factoid	Which river runs through Dublin?	\bLiffey\b|\bDodder\b|\bTolka\b
+2058	factoid	What is the motto of the "New York Times"?	\ball the news that's fit to print\b
+2264	factoid	How old was Elvis when he died?	\b42\b
+1827	factoid	Where was the battle of Alamo fought?	\bSan Antonio\b|\bTexas\b
 10060	factoid	how many countries are in european union?	\b2[78]\b
-1858	factoid	Tell me where the DuPont company is located.	Wilmington|Delaware|United States
-1779	factoid	What is Australia's oldest city?	Sydney
-2241	factoid	How tall is the green monster at Fenway?	(37|thirty.seven)\s*f(ee|oo)?t|11.*m|the 37\-foot\-tall
-1891	factoid	Who was the first black heavyweight champion?	Jack Johnson|Johnson
-1666	factoid	What is the name of the US military base in Cuba?	Guant[aá]namo
-10084	factoid	what is the national anthem of usa?	The Star-Spangled Banner|the American national anthem\,
-2277	factoid	In which country is Timbuktu?	Mali
-1835	factoid	Who was Sherlock Holmes' arch enemy?	Moriarty
-1959	factoid	What does cc mean in letter writing?	carbon copy
-1396	factoid	What is the name of the volcano that destroyed the ancient city of Pompeii?	Vesuvius
-1717	factoid	What city was the first in the world to have a population over one million?	London|Xi'an
-1657	factoid	What do the French call the English Channel?	La Manche
-2382	factoid	What passage has the Ten Commandments?	Exodus|Deuteronomy
-1823	factoid	What number did Michael Jordan wear?	(23|45)|Twenty-three
-1516	factoid	What does CPR stand for?	Contraceptive Prevalence Rate|cardio\s?-?\s?pulm(o|i)nary resuscitation
-1655	factoid	Where was Abraham Lincoln born?	Kentucky|Larue County|Hardin County|Hodgenville
-1912	factoid	In which capital city is the River Seine?	Paris
-1921	factoid	How did Virginia Woolf die?	river|drown|suicide
-1399	factoid	What mythical Scottish town appears for one day every 100 years?	Brigadoon|only one day
-1920	factoid	When was "Cold Mountain" written?	1997
-1798	factoid	On what continent is Egypt located?	African?
-2139	factoid	What gas is 78 percent of the earth's atmosphere?	nitrogen
-2311	factoid	How did the Lindy Hop get its name?	Lindbergh|Snowden
-2319	factoid	What common medicine discovered by native Americans is from the bark of a willow tree?	aspirin
-2303	factoid	What is the longest river in the world?	Amazon|Nile
-10026	factoid	What is the name of the computer which beat Kasparov at chess in 1997?	Deep Blue
-10100	factoid	who discovered transposable elements - transposons?	McClintock
-1680	factoid	What country was ruled by King Arthur?	Britain|Engl(and|ish)
-1401	factoid	What is the democratic party symbol?	donkey
-1758	factoid	What is the "Sunflower State"?	Kansas
-1831	factoid	What is the name of Abbott and Costello's famous routine?	Who's on First
-10075	factoid	what is the inode number of the root directory in the reiser4 file system?	-1\b
-1435	factoid	What nation is home to the Kaaba?	Saudi Arabia
-2048	factoid	When was MTV started?	1981
-10068	factoid	in which country was osama bin laden killed?	Pakistan
-2023	factoid	What continent is the world's largest dessert on?	Africa
-1780	factoid	Who has the most no hitters in major league baseball?	Ryan
-1624	factoid	What year did "New Coke" come out?	1985
-1668	factoid	What is the oldest national park in the U.S.?	Yellowstone
-1555	factoid	When was the Tet offensive in Vietnam?	1968
-1559	factoid	Where did Dr. King give his speech in Washington?	Lincoln Memorial
-1409	factoid	Which vintage rock and roll singer was known as "The Killer"?	Jerry Lee Lewis
-1493	factoid	When was Davy Crockett born?	1786|August 17
-2016	factoid	What is the area of western Germany that is known for its rich coal deposits?	Ruhr
-2027	factoid	When was OJ Simpson arrested for murder?	1994
-1999	factoid	What is the state with the smallest population?	Wyoming|Pitcairn|Vatican
-1573	factoid	Who was the first head of the FBI?	Hoover
-2299	factoid	How many mph do you have to go to break the sound barrier?	763.035|about 750|761|770 mph|Mach\ 1\.012 or 1\,240\ km\/h \(776\.2\ mph\) while in a controlled dive through 41\,088\ feet \(12\,510\ m\)
-1880	factoid	When was King Louis XIV born?	1638
-1970	factoid	What is the national airline of Spain?	Iberia
-2310	factoid	How many American deaths were there in the Korean war?	\b3[0-9],?[0-9]{3}\b|The casualty toll had been reported as 54\,246 until June 2000
-2247	factoid	What major league baseball player has 511 pitching victories?	Cy Young
-10095	factoid	where you can find pyramids?	Egypt
-1953	factoid	How many NFL teams are there?	3[12]
-1474	factoid	What is the lowest point on dry land?	Dead Sea
-2106	factoid	What is Barbie's full name?	(Barbie|Barbara) Millicent Roberts
-10033	factoid	When was Declaration of Independence signed?	1776|July 4
-1737	factoid	How much sleep should a child get at night?	((9|1[0-5])\s*(-|to)?\s*)+h(our)?
-2168	factoid	What country produces the most emeralds?	Colombia
-2273	factoid	Which religion has the largest number of followers worldwide?	Christian|Roman Catholic
-10080	factoid	what is the name of Kirk's starship?	Enterprise
-2262	factoid	How did Cincinnati get its name?	Cincinnatus|Arthur St. Clair
-1878	factoid	What year was the phonograph invented?	187(7|8)
-1551	factoid	What does DNA stand for?	deoxyribonucleic acid
-2072	factoid	How did Brandon Lee die?	shooting|gunshot|film|movie|Accident
-10101	factoid	who invented dynamite ?	Alfred Nobel|Nobel
-1443	factoid	When did Bob Marley die?	1981
-2179	factoid	What famous verse did Sarah Hale write in 1830?	Mary Had a Little Lamb|Mary's Lamb
-2292	factoid	What do you call a bone doctor?	Orthopedic|Orthopedist|Orthopaedic surgery or orthopaedics
-1586	factoid	When did the Golden Gate Bridge get finished?	193(7|0s)
-1802	factoid	How tall is Tom Cruise?	5\s*(f(ee|oo)?t|')\s*7\s*(in(ch.*)?|")
-1813	factoid	When were the first postage stamps issued in the United States?	1847
-1455	factoid	The Hindenburg disaster took place in 1937 in which New Jersey town?	Lakehurst
-1693	factoid	When was Jackie Robinson born?	1919
-1538	factoid	Who is the evil H.R. Director in "Dilbert"?	Catbert
+1858	factoid	Tell me where the DuPont company is located.	\bWilmington\b|\bDelaware\b|\bUnited States\b
+1779	factoid	What is Australia's oldest city?	\bSydney\b
+2241	factoid	How tall is the green monster at Fenway?	\b(37|thirty.seven)\s*f(ee|oo)?t\b|\b11.*m\b|\bthe 37\-foot\-tall\b
+1891	factoid	Who was the first black heavyweight champion?	\bJack Johnson\b|\bJohnson\b
+1666	factoid	What is the name of the US military base in Cuba?	\bGuant[aá]namo\b
+10084	factoid	what is the national anthem of usa?	\bThe Star-Spangled Banner\b|\bthe American national anthem\,\b
+2277	factoid	In which country is Timbuktu?	\bMali\b
+1835	factoid	Who was Sherlock Holmes' arch enemy?	\bMoriarty\b
+1959	factoid	What does cc mean in letter writing?	\bcarbon copy\b
+1396	factoid	What is the name of the volcano that destroyed the ancient city of Pompeii?	\bVesuvius\b
+1717	factoid	What city was the first in the world to have a population over one million?	\bLondon\b|\bXi'an\b
+1657	factoid	What do the French call the English Channel?	\bLa Manche\b
+2382	factoid	What passage has the Ten Commandments?	\bExodus\b|\bDeuteronomy\b
+1823	factoid	What number did Michael Jordan wear?	\b(23|45)\b|\bTwenty-three\b
+1516	factoid	What does CPR stand for?	\bContraceptive Prevalence Rate\b|\bcardio\s?-?\s?pulm(o|i)nary resuscitation\b
+1655	factoid	Where was Abraham Lincoln born?	\bKentucky\b|\bLarue County\b|\bHardin County\b|\bHodgenville\b
+1912	factoid	In which capital city is the River Seine?	\bParis\b
+1921	factoid	How did Virginia Woolf die?	\briver\b|\bdrown\b|\bsuicide\b
+1399	factoid	What mythical Scottish town appears for one day every 100 years?	\bBrigadoon\b|\bonly one day\b
+1920	factoid	When was "Cold Mountain" written?	\b1997\b
+1798	factoid	On what continent is Egypt located?	\bAfrican?\b
+2139	factoid	What gas is 78 percent of the earth's atmosphere?	\bnitrogen\b
+2311	factoid	How did the Lindy Hop get its name?	\bLindbergh\b|\bSnowden\b
+2319	factoid	What common medicine discovered by native Americans is from the bark of a willow tree?	\baspirin\b
+2303	factoid	What is the longest river in the world?	\bAmazon\b|\bNile\b
+10026	factoid	What is the name of the computer which beat Kasparov at chess in 1997?	\bDeep Blue\b
+10100	factoid	who discovered transposable elements - transposons?	\bMcClintock\b
+1680	factoid	What country was ruled by King Arthur?	\bBritain\b|\bEngl(and|ish)\b
+1401	factoid	What is the democratic party symbol?	\bdonkey\b
+1758	factoid	What is the "Sunflower State"?	\bKansas\b
+1831	factoid	What is the name of Abbott and Costello's famous routine?	\bWho's on First\b
+10075	factoid	what is the inode number of the root directory in the reiser4 file system?	\b-1\b
+1435	factoid	What nation is home to the Kaaba?	\bSaudi Arabia\b
+2048	factoid	When was MTV started?	\b1981\b
+10068	factoid	in which country was osama bin laden killed?	\bPakistan\b
+2023	factoid	What continent is the world's largest dessert on?	\bAfrica\b
+1780	factoid	Who has the most no hitters in major league baseball?	\bRyan\b
+1624	factoid	What year did "New Coke" come out?	\b1985\b
+1668	factoid	What is the oldest national park in the U.S.?	\bYellowstone\b
+1555	factoid	When was the Tet offensive in Vietnam?	\b1968\b
+1559	factoid	Where did Dr. King give his speech in Washington?	\bLincoln Memorial\b
+1409	factoid	Which vintage rock and roll singer was known as "The Killer"?	\bJerry Lee Lewis\b
+1493	factoid	When was Davy Crockett born?	\b1786\b|\bAugust 17\b
+2016	factoid	What is the area of western Germany that is known for its rich coal deposits?	\bRuhr\b
+2027	factoid	When was OJ Simpson arrested for murder?	\b1994\b
+1999	factoid	What is the state with the smallest population?	\bWyoming\b|\bPitcairn\b|\bVatican\b
+1573	factoid	Who was the first head of the FBI?	\bHoover\b
+2299	factoid	How many mph do you have to go to break the sound barrier?	\b763.035\b|\babout 750\b|\b761\b|\b770 mph\b|\bMach\ 1\.012 or 1\,240\ km\/h \(776\.2\ mph\) while in a controlled dive through 41\,088\ feet \(12\,510\ m\)\b
+1880	factoid	When was King Louis XIV born?	\b1638\b
+1970	factoid	What is the national airline of Spain?	\bIberia\b
+2310	factoid	How many American deaths were there in the Korean war?	\b3[0-9],?[0-9]{3}\b|\bThe casualty toll had been reported as 54\,246 until June 2000\b
+2247	factoid	What major league baseball player has 511 pitching victories?	\bCy Young\b
+10095	factoid	where you can find pyramids?	\bEgypt\b
+1953	factoid	How many NFL teams are there?	\b3[12]\b
+1474	factoid	What is the lowest point on dry land?	\bDead Sea\b
+2106	factoid	What is Barbie's full name?	\b(Barbie|Barbara) Millicent Roberts\b
+10033	factoid	When was Declaration of Independence signed?	\b1776\b|\bJuly 4\b
+1737	factoid	How much sleep should a child get at night?	\b((9|1[0-5])\s*(-|to)?\s*)+h(our)?\b
+2168	factoid	What country produces the most emeralds?	\bColombia\b
+2273	factoid	Which religion has the largest number of followers worldwide?	\bChristian\b|\bRoman Catholic\b
+10080	factoid	what is the name of Kirk's starship?	\bEnterprise\b
+2262	factoid	How did Cincinnati get its name?	\bCincinnatus\b|\bArthur St. Clair\b
+1878	factoid	What year was the phonograph invented?	\b187(7|8)\b
+1551	factoid	What does DNA stand for?	\bdeoxyribonucleic acid\b
+2072	factoid	How did Brandon Lee die?	\bshooting\b|\bgunshot\b|\bfilm\b|\bmovie\b|\bAccident\b
+10101	factoid	who invented dynamite ?	\bAlfred Nobel\b|\bNobel\b
+1443	factoid	When did Bob Marley die?	\b1981\b
+2179	factoid	What famous verse did Sarah Hale write in 1830?	\bMary Had a Little Lamb\b|\bMary's Lamb\b
+2292	factoid	What do you call a bone doctor?	\bOrthopedic\b|\bOrthopedist\b|\bOrthopaedic surgery or orthopaedics\b
+1586	factoid	When did the Golden Gate Bridge get finished?	\b193(7|0s)\b
+1802	factoid	How tall is Tom Cruise?	\b5\s*(f(ee|oo)?t\b|\b')\s*7\s*(in(ch.*)?\b|\b")\b
+1813	factoid	When were the first postage stamps issued in the United States?	\b1847\b
+1455	factoid	The Hindenburg disaster took place in 1937 in which New Jersey town?	\bLakehurst\b
+1693	factoid	When was Jackie Robinson born?	\b1919\b
+1538	factoid	Who is the evil H.R. Director in "Dilbert"?	\bCatbert\b
 2211	factoid	How large of a litter does a rat have at one time?	\b(7|seven|14|11|10|12)\b
-2381	factoid	What is Horatio's relationship to Hamlet?	friend
-2251	factoid	How deep is the Grand Canyon?	(1|a) mile|(6,?000|5,?700)\s*f(ee|oo|')?t|1,?[68]00\s*m|1.6\s*km
-1575	factoid	What is the degree of tilt of Earth?	23.4?5
-1864	factoid	What was the name of the first child of English parents to be born in America?	Virginia Dare
-2039	factoid	What college did Allen Iverson go to?	Georgetown
-2164	factoid	How did Julius Irving's son die?	cocaine|drown
-1619	factoid	Which baseball star stole 130 bases in 1982?	Henderson
-10042	factoid	Which space shuttle exploded?	((Columbia|Challenger).*){2}|the Challenger Space Shuttle|The space shuttle Challenger
-10085	factoid	what is the nearest planet to the sun?	Mercury
-1512	factoid	What is the age of our solar system?	4.(5[0-9]*|6) billion years
-2178	factoid	How high is Mt. Hood?	11,?24[0-9]\s*f(oo|ee)?t|3,?429\s*m|11\,250 feet
-2013	factoid	How many stripes are on the American flag?	13|thirteen
-2340	factoid	What instrument did the jazz musician Art Tatum play?	pian(o|ist)
-2350	factoid	How big is the killer whale?	\b[68]\s*m|2[0-6]\s*f(ee|oo)?t|\b[56]\b(\s*t|.*ton)
-1661	factoid	What does "E Pluribus Unum" mean?	out of .*many\s?, one
-1440	factoid	Who was the lead singer for the Commodores?	Lionel Richie
-1950	factoid	Who created the literary character Phineas Fogg?	Verne
-1996	factoid	What city is Duke University in?	Durham
-1937	factoid	How fast can a nuclear submarine travel?	(25|30|33)\s*knots|29\s*(mph|miles per hour)|46\s*(kph|kilometers per hour)
-1814	factoid	What gift is proper for a 1st anniversary?	paper|plastic|clock
-1740	factoid	What is the Stanley Cup made of?	silver
-1517	factoid	What is the state bird of Alaska?	willow ptarmigans?|\(Lagopus lagopus\)
-10030	factoid	What language is spoken in Latin America?	((spanish|portuguese).*){2}|spanish|portuguese|Romance languages
-1433	factoid	What is the height of the tallest redwood?	367 1/2|367.5|370\s?-\s?foot(-tall)?|379\s*f(ee|oo)?t|115.5\s*m|93\.6 m|379\.7 feet|115\.7 meters
-10050	factoid	Who wrote "Strange Case of Dr Jekyll and Mr Hyde" ?	Stevenson
-1747	factoid	Where is the national hurricane center located?	Miami|Florida
-2347	factoid	Where is Mount Olympus?	Greece|the Balkans
-1810	factoid	Where are the British Crown jewels kept?	London Tower|Tower of London|London|the Tower
-2161	factoid	What is the nickname for the national New Zealand basketball team?	Tall Blacks|Kiwis
-1578	factoid	How tall is the Sphinx?	20 met(er|re)s?|20\s*m|66\s*f(ee|oo)?t
+2381	factoid	What is Horatio's relationship to Hamlet?	\bfriend\b
+2251	factoid	How deep is the Grand Canyon?	\b(1|a) mile\b|\b(6,?000|5,?700)\s*f(ee|oo|')?t\b|\b1,?[68]00\s*m\b|\b1.6\s*km\b
+1575	factoid	What is the degree of tilt of Earth?	\b23.4?5\b
+1864	factoid	What was the name of the first child of English parents to be born in America?	\bVirginia Dare\b
+2039	factoid	What college did Allen Iverson go to?	\bGeorgetown\b
+2164	factoid	How did Julius Irving's son die?	\bcocaine\b|\bdrown\b
+1619	factoid	Which baseball star stole 130 bases in 1982?	\bHenderson\b
+10042	factoid	Which space shuttle exploded?	\b((Columbia|Challenger).*){2}\b|\bthe Challenger Space Shuttle\b|\bThe space shuttle Challenger\b
+10085	factoid	what is the nearest planet to the sun?	\bMercury\b
+1512	factoid	What is the age of our solar system?	\b4.(5[0-9]*|6) billion years\b
+2178	factoid	How high is Mt. Hood?	\b11,?24[0-9]\s*f(oo|ee)?t\b|\b3,?429\s*m\b|\b11\,250 feet\b
+2013	factoid	How many stripes are on the American flag?	\b13\b|\bthirteen\b
+2340	factoid	What instrument did the jazz musician Art Tatum play?	\bpian(o|ist)\b
+2350	factoid	How big is the killer whale?	\b[68]\s*m\b|\b2[0-6]\s*f(ee|oo)?t\b|\b[56]\b(\s*t|.*ton)\b
+1661	factoid	What does "E Pluribus Unum" mean?	\bout of .*many\s?, one\b
+1440	factoid	Who was the lead singer for the Commodores?	\bLionel Richie\b
+1950	factoid	Who created the literary character Phineas Fogg?	\bVerne\b
+1996	factoid	What city is Duke University in?	\bDurham\b
+1937	factoid	How fast can a nuclear submarine travel?	\b(25|30|33)\s*knots\b|\b29\s*(mph|miles per hour)\b|\b46\s*(kph|kilometers per hour)\b
+1814	factoid	What gift is proper for a 1st anniversary?	\bpaper\b|\bplastic\b|\bclock\b
+1740	factoid	What is the Stanley Cup made of?	\bsilver\b
+1517	factoid	What is the state bird of Alaska?	\bwillow ptarmigans?\b|\b\(Lagopus lagopus\)\b
+10030	factoid	What language is spoken in Latin America?	\b((spanish|portuguese).*){2}\b|\bspanish\b|\bportuguese\b|\bRomance languages\b
+1433	factoid	What is the height of the tallest redwood?	\b367 1/2\b|\b367.5\b|\b370\s?-\s?foot(-tall)?\b|\b379\s*f(ee|oo)?t\b|\b115.5\s*m\b|\b93\.6 m\b|\b379\.7 feet\b|\b115\.7 meters\b
+10050	factoid	Who wrote "Strange Case of Dr Jekyll and Mr Hyde" ?	\bStevenson\b
+1747	factoid	Where is the national hurricane center located?	\bMiami\b|\bFlorida\b
+2347	factoid	Where is Mount Olympus?	\bGreece\b|\bthe Balkans\b
+1810	factoid	Where are the British Crown jewels kept?	\bLondon Tower\b|\bTower of London\b|\bLondon\b|\bthe Tower\b
+2161	factoid	What is the nickname for the national New Zealand basketball team?	\bTall Blacks\b|\bKiwis\b
+1578	factoid	How tall is the Sphinx?	\b20 met(er|re)s?\b|\b20\s*m\b|\b66\s*f(ee|oo)?t\b
 10072	factoid	what is the atomic number of Uranium?	\b92\b
-2192	factoid	How did Malcolm X die?	assassin|murder|shot
-1939	factoid	How did Einstein die?	abdominal.*aneurysm|Ulm\, Wurttemberg\, Germany Location of death
-1984	factoid	What are people born 1965 through 1980 called?	Generation X|1963\–1980
-2087	factoid	What Canadian city has the largest population?	Toronto
-1925	factoid	What did Ozzy Osbourne bite the head off of?	bat|\– Ozzy Osbourne
-2356	factoid	What instrument did Louis Armstrong play?	cornet|trumpet|August 4\, 1901
-1968	factoid	What fruit's stone does Laetrile come from?	apricot|the seeds of stone fruits of the Prunus genus
-2044	factoid	What museum in Philadelphia was used in "Rocky"?	Art\s+Museum|Museum of Art
-1938	factoid	How many floors are in the Empire State Building?	102|104 floors|more than 100 floors
-1449	factoid	What college did Magic Johnson attend?	Michigan State
-1735	factoid	What city is Southwestern University in?	Georgetown,?
-2184	factoid	What Liverpool club spawned the Beatles?	Cavern
-10078	factoid	what is the moon of mars?	((Phobos|Deimos).*){2}
-1896	factoid	What was the Hunchback of Notre Dame's real name?	Quasimodo
-1746	factoid	Who stabbed Monica Seles?	Parche|Graf fan|fan of (Steffi )?Graf|Graf
-1757	factoid	When did the battle of Iwo Jima take place?	1944|1945
-2260	factoid	When was the hot air balloon invented?	1783
-1605	factoid	How far would you run if you participate in a marathon?	26(.2)?\s?-?\s?miles?|42.195 kilometers
-2352	factoid	What engineer designed the Erie Canal?	Benjamin Wright
-1805	factoid	Who was elected President of South Africa in 1994?	Mandela
-2358	factoid	Who was responsible for the killing of Duncan in "Macbeth"?	Macbeth
-1472	factoid	How do you say "house" in Spanish?	casa
-2045	factoid	When was the city of New Orleans founded?	1718
-2370	factoid	When was the first potato chip made?	1853
-10043	factoid	Who discovered polarography?	Heyrovsk[yý]
-2296	factoid	What national monument was designated as the first national monument in 1906?	Devils Tower
-1753	factoid	When was the Vietnam Veterans Memorial in Washington, D.C. built?	1982
-1561	factoid	When was the first patent filed on the ice cream cone?	1903|1902|1904
-1616	factoid	When is Gerald Ford's birthday?	July 14, 1913
-2341	factoid	When was barbed wire invented?	1867
-2226	factoid	When was abortion legalized in the U.S.?	1973
-2242	factoid	What chemical is in chocolate that helps with depression?	phenylethylamine|dopamine|serotonin
-2294	factoid	What continent is India on?	Asia
-1484	factoid	What college did Allen Iverson attend?	Georgetown
-10089	factoid	when did the biggest underground terror attack happen?	2005|2004
-2320	factoid	When was the first TV invented?	192[567]
-1451	factoid	Where was the first McDonalds built?	California|San Bernardino( , Calif.)?
-1721	factoid	How far is the pitchers mound from home plate in softball?	46\s*f(ee|oo)?t
-1755	factoid	What was the profession of American patriot Paul Revere?	silversmith|engraver
-10083	factoid	what is the national anthem of czech republic?	Kde domov m[uů]j|Where is my home
-1478	factoid	What is the name of the heroine in "Gone with the Wind"?	Scarlett
-1410	factoid	What lays blue eggs?	Ameracuana|Aracuana|Starlings |The Ameraucana| bluebird eggs
-2169	factoid	What day did Pearl Harbor occur?	Dec\s?(ember|.) 7,?|Sunday|1941\-12\-07
-10102	factoid	who invented the tesla coil?	Nikola Tesla
-1954	factoid	What country made the Statue of Liberty?	France
-2074	factoid	How tall is the tallest pyramid?	14[67].*\bm|481\s*f(ee|oo)?t|13[89].*\bm|455\s*f(ee|oo)?t
-2036	factoid	How many counties are in California?	58
-1421	factoid	When did Mike Tyson bite Holyfield's ear?	1997
-10008	factoid	What color is the computer which beat Kasparov at chess in 1997?	blue
-2119	factoid	When is Jennifer Lopez's birthday?	July 24,?|1969
-1542	factoid	Where is Hill Air Force Base?	Ogden,?|Utah|about 120 kilometers west of Salt_Lake_City
-1697	factoid	Where is the Statue of Liberty?	N(\.|ew)\s?Y(ork)?|Liberty Island|the United States
-2061	factoid	What court case overturned Plessy v. Furgeson?	Brown vs?. Board of Education
-1705	factoid	What is rum made out of?	molasses|sugar cane|sugarcane juice
-10034	factoid	When was Google founded?	1998
-1676	factoid	When was liquid water found on Mars?	June 2[12]\s*,\s* 2000|2012|1965|September 28 2015
-1775	factoid	What is a group of antelope called?	herd
-1457	factoid	Who succeeded Ferdinand Marcos?	Corazon Aquino
-2326	factoid	How far is it from the pitcher's mound to home plate?	60\s*('|f(ee|oo)?t).*6\s*(in|")|18.4\s*m
-2035	factoid	How many stomachs does a cow have?	four|\b4\b
+2192	factoid	How did Malcolm X die?	\bassassin\b|\bmurder\b|\bshot\b
+1939	factoid	How did Einstein die?	\babdominal.*aneurysm\b|\bUlm\, Wurttemberg\, Germany Location of death\b
+1984	factoid	What are people born 1965 through 1980 called?	\bGeneration X\b|\b1963\–1980\b
+2087	factoid	What Canadian city has the largest population?	\bToronto\b
+1925	factoid	What did Ozzy Osbourne bite the head off of?	\bbat\b|\b\– Ozzy Osbourne\b
+2356	factoid	What instrument did Louis Armstrong play?	\bcornet\b|\btrumpet\b|\bAugust 4\, 1901\b
+1968	factoid	What fruit's stone does Laetrile come from?	\bapricot\b|\bthe seeds of stone fruits of the Prunus genus\b
+2044	factoid	What museum in Philadelphia was used in "Rocky"?	\bArt\s+Museum\b|\bMuseum of Art\b
+1938	factoid	How many floors are in the Empire State Building?	\b102\b|\b104 floors\b|\bmore than 100 floors\b
+1449	factoid	What college did Magic Johnson attend?	\bMichigan State\b
+1735	factoid	What city is Southwestern University in?	\bGeorgetown,?\b
+2184	factoid	What Liverpool club spawned the Beatles?	\bCavern\b
+10078	factoid	what is the moon of mars?	\b((Phobos|Deimos).*){2}\b
+1896	factoid	What was the Hunchback of Notre Dame's real name?	\bQuasimodo\b
+1746	factoid	Who stabbed Monica Seles?	\bParche\b|\bGraf fan\b|\bfan of (Steffi )?Graf\b|\bGraf\b
+1757	factoid	When did the battle of Iwo Jima take place?	\b1944\b|\b1945\b
+2260	factoid	When was the hot air balloon invented?	\b1783\b
+1605	factoid	How far would you run if you participate in a marathon?	\b26(.2)?\s?-?\s?miles?\b|\b42.195 kilometers\b
+2352	factoid	What engineer designed the Erie Canal?	\bBenjamin Wright\b
+1805	factoid	Who was elected President of South Africa in 1994?	\bMandela\b
+2358	factoid	Who was responsible for the killing of Duncan in "Macbeth"?	\bMacbeth\b
+1472	factoid	How do you say "house" in Spanish?	\bcasa\b
+2045	factoid	When was the city of New Orleans founded?	\b1718\b
+2370	factoid	When was the first potato chip made?	\b1853\b
+10043	factoid	Who discovered polarography?	\bHeyrovsk[yý]\b
+2296	factoid	What national monument was designated as the first national monument in 1906?	\bDevils Tower\b
+1753	factoid	When was the Vietnam Veterans Memorial in Washington, D.C. built?	\b1982\b
+1561	factoid	When was the first patent filed on the ice cream cone?	\b1903\b|\b1902\b|\b1904\b
+1616	factoid	When is Gerald Ford's birthday?	\bJuly 14, 1913\b
+2341	factoid	When was barbed wire invented?	\b1867\b
+2226	factoid	When was abortion legalized in the U.S.?	\b1973\b
+2242	factoid	What chemical is in chocolate that helps with depression?	\bphenylethylamine\b|\bdopamine\b|\bserotonin\b
+2294	factoid	What continent is India on?	\bAsia\b
+1484	factoid	What college did Allen Iverson attend?	\bGeorgetown\b
+10089	factoid	when did the biggest underground terror attack happen?	\b2005\b|\b2004\b
+2320	factoid	When was the first TV invented?	\b192[567]\b
+1451	factoid	Where was the first McDonalds built?	\bCalifornia\b|\bSan Bernardino( , Calif.)?\b
+1721	factoid	How far is the pitchers mound from home plate in softball?	\b46\s*f(ee|oo)?t\b
+1755	factoid	What was the profession of American patriot Paul Revere?	\bsilversmith\b|\bengraver\b
+10083	factoid	what is the national anthem of czech republic?	\bKde domov m[uů]j\b|\bWhere is my home\b
+1478	factoid	What is the name of the heroine in "Gone with the Wind"?	\bScarlett\b
+1410	factoid	What lays blue eggs?	\bAmeracuana\b|\bAracuana\b|\bStarlings \b|\bThe Ameraucana\b|\b bluebird eggs\b
+2169	factoid	What day did Pearl Harbor occur?	\bDec\s?(ember|.) 7,?\b|\bSunday\b|\b1941\-12\-07\b
+10102	factoid	who invented the tesla coil?	\bNikola Tesla\b
+1954	factoid	What country made the Statue of Liberty?	\bFrance\b
+2074	factoid	How tall is the tallest pyramid?	\b14[67].*\bm\b|\b481\s*f(ee|oo)?t\b|\b13[89].*\bm\b|\b455\s*f(ee|oo)?t\b
+2036	factoid	How many counties are in California?	\b58\b
+1421	factoid	When did Mike Tyson bite Holyfield's ear?	\b1997\b
+10008	factoid	What color is the computer which beat Kasparov at chess in 1997?	\bblue\b
+2119	factoid	When is Jennifer Lopez's birthday?	\bJuly 24,?\b|\b1969\b
+1542	factoid	Where is Hill Air Force Base?	\bOgden,?\b|\bUtah\b|\babout 120 kilometers west of Salt_Lake_City\b
+1697	factoid	Where is the Statue of Liberty?	\bN(\.|ew)\s?Y(ork)?\b|\bLiberty Island\b|\bthe United States\b
+2061	factoid	What court case overturned Plessy v. Furgeson?	\bBrown vs?. Board of Education\b
+1705	factoid	What is rum made out of?	\bmolasses\b|\bsugar cane\b|\bsugarcane juice\b
+10034	factoid	When was Google founded?	\b1998\b
+1676	factoid	When was liquid water found on Mars?	\bJune 2[12]\s*,\s* 2000\b|\b2012\b|\b1965\b|\bSeptember 28 2015\b
+1775	factoid	What is a group of antelope called?	\bherd\b
+1457	factoid	Who succeeded Ferdinand Marcos?	\bCorazon Aquino\b
+2326	factoid	How far is it from the pitcher's mound to home plate?	\b60\s*('|f(ee|oo)?t).*6\s*(in|")\b|\b18.4\s*m\b
+2035	factoid	How many stomachs does a cow have?	\bfour\b|\b4\b
 2244	factoid	What dress size was Marilyn Monroe?	\b(14|12|8|4)\b
-1694	factoid	What year did California become a territory?	1848
-2271	factoid	What class of drug is Xanax?	.*anxi.*|psychoactive|Benzodiazepine
-1825	factoid	What year did Nintendo 64 come out?	1996
-1518	factoid	What year did Marco Polo travel to Asia?	1271
-1514	factoid	What is Canada's most populous city?	Toronto
-2228	factoid	What country was the Battle of Verdun fought in?	France|The Battle of Verdun 1916\.
-1687	factoid	What president declared Mothers' Day?	Wilson
-1589	factoid	Who was the only golfer to win the U.S. and British Opens and amateurs in the same year?	Bobby Jones|Jones
-1701	factoid	Where was President Lincoln buried?	Oak Ridge Cemetery|Illinois|Springfield
-1691	factoid	Where was the movie "Somewhere in Time" filmed?	Grand Hotel|Mackinac Island
-10027	factoid	What is the name of the longest running soap opera TV series?	Coronation Street
-2313	factoid	What does an English stone equal?	14 pound|6.*(kg|kilogram)
-2107	factoid	What is the currency of Denmark?	kroner?|DKK
-1749	factoid	When was Sputnik launched?	1957
-1523	factoid	What percent of the U.S. is African American?	12(\.2)?\s*(percent|%)|13\.2\%|between 12\.3 and 13\.2
-2392	factoid	When was the Red Cross founded?	1859|186[234]|1919
-2101	factoid	What country was Catherine the Great from?	Prussia|Russia
-2151	factoid	What cathedral is in Claude Monet's paintings?	Rouen
-10107	factoid	who received the Nobel Prize for Physiology and Medicine in the year 2012?	((Gurdon|Yamanaka).*){2}
-1945	factoid	When was Adolf Hitler born?	1889|20 April
-1857	factoid	What is the length of Churchill Downs racetrack?	seven furlongs|1.* mile|2 k(ilo)?m(eters)?
-2217	factoid	What country does Greenland belong to?	Denmark
-1510	factoid	Where is Anne Frank's diary?	Amsterdam|Anne Frank House|the Netherlands
-1469	factoid	When did Alexandra Graham Bell invent the telephone?	1876
+1694	factoid	What year did California become a territory?	\b1848\b
+2271	factoid	What class of drug is Xanax?	\b.*anxi.*\b|\bpsychoactive\b|\bBenzodiazepine\b
+1825	factoid	What year did Nintendo 64 come out?	\b1996\b
+1518	factoid	What year did Marco Polo travel to Asia?	\b1271\b
+1514	factoid	What is Canada's most populous city?	\bToronto\b
+2228	factoid	What country was the Battle of Verdun fought in?	\bFrance\b|\bThe Battle of Verdun 1916\.\b
+1687	factoid	What president declared Mothers' Day?	\bWilson\b
+1589	factoid	Who was the only golfer to win the U.S. and British Opens and amateurs in the same year?	\bBobby Jones\b|\bJones\b
+1701	factoid	Where was President Lincoln buried?	\bOak Ridge Cemetery\b|\bIllinois\b|\bSpringfield\b
+1691	factoid	Where was the movie "Somewhere in Time" filmed?	\bGrand Hotel\b|\bMackinac Island\b
+10027	factoid	What is the name of the longest running soap opera TV series?	\bCoronation Street\b
+2313	factoid	What does an English stone equal?	\b14 pound\b|\b6.*(kg|kilogram)\b
+2107	factoid	What is the currency of Denmark?	\bkroner?\b|\bDKK\b
+1749	factoid	When was Sputnik launched?	\b1957\b
+1523	factoid	What percent of the U.S. is African American?	\b12(\.2)?\s*(percent|%)\b|\b13\.2\%\b|\bbetween 12\.3 and 13\.2\b
+2392	factoid	When was the Red Cross founded?	\b1859\b|\b186[234]\b|\b1919\b
+2101	factoid	What country was Catherine the Great from?	\bPrussia\b|\bRussia\b
+2151	factoid	What cathedral is in Claude Monet's paintings?	\bRouen\b
+10107	factoid	who received the Nobel Prize for Physiology and Medicine in the year 2012?	\b((Gurdon|Yamanaka).*){2}\b
+1945	factoid	When was Adolf Hitler born?	\b1889\b|\b20 April\b
+1857	factoid	What is the length of Churchill Downs racetrack?	\bseven furlongs\b|\b1.* mile\b|\b2 k(ilo)?m(eters)?\b
+2217	factoid	What country does Greenland belong to?	\bDenmark\b
+1510	factoid	Where is Anne Frank's diary?	\bAmsterdam\b|\bAnne Frank House\b|\bthe Netherlands\b
+1469	factoid	When did Alexandra Graham Bell invent the telephone?	\b1876\b
 10062	factoid	how many lines per page are in Gutenberg bible?	\b42\b
 10067	factoid	in which country was microsoft founded?	\bU(nited|\.)?\s*S(tates|\.)?\b


### PR DESCRIPTION
Add word boundary to all labeled answers, to make sure that answer evaluation does not capture wrong results.

For example, if labeled answer is "23", the evaluation would have marked 16723 as proper answer since 23 is contained in 16723. Using word boundary avoids such errors.